### PR TITLE
Update mailman sync to look at only new users

### DIFF
--- a/chameleon/urls.py
+++ b/chameleon/urls.py
@@ -51,8 +51,9 @@ urlpatterns = patterns(
         url(r'^feed\.xml', RedirectView.as_view(url=reverse_lazy('user_news:feed'))),
 
         # mailing list resource for mailman autosubscribe
-        url(r'^mailman/(?P<list_name>\w+)\.txt$',
+        url(r'^mailman/new_members.txt$',
             'chameleon_mailman.views.mailman_export_list', name='mailman_export_list'),
+        
         # cms urls
         url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
         url(r'^', include('blog_comments.urls')),

--- a/chameleon_mailman/views.py
+++ b/chameleon_mailman/views.py
@@ -1,4 +1,5 @@
 from chameleon_token.decorators import token_required
+from datetime import datetime
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
 from django.contrib import messages
@@ -9,33 +10,20 @@ from .models import MailmanSubscription
 from .forms import MailmanSubscriptionForm
 import logging
 
-
 logger = logging.getLogger('default')
 
-def is_user_subscribed_to_list(user, list_name):
-    try:
-        if list_name == 'users_list':
-            subscribed = user.subscriptions.users_list
-        elif list_name == 'outages_list':
-            subscribed = user.subscriptions.outage_notifications
-        else:
-            raise Exception('Unknown list "%s"' % list_name)
-    except MailmanSubscription.DoesNotExist:
-        subscribed = True # users are subscribed by default
-
-    return subscribed
-
 @token_required
-def mailman_export_list(request, list_name):
+def mailman_export_list(request):
     """
     Returns a text file, listing the email addresses, one per line, of all
-    active (in Chamelon portal) Chameleon Users subscribed to the given list.
+    users who joined in the last day.
     """
     try:
-        users = get_user_model().objects.filter(is_active=True)
-        content = list(u.email for u in users if is_user_subscribed_to_list(u, list_name))
+        users = get_user_model().objects.filter(is_active=True,
+                                                date_joined__gte=datetime.today())
+        content = list(u.email for u in users)
         response = HttpResponse('\n'.join(content), content_type='text/plain')
-        response['Content-Disposition'] = 'attachment; filename="%s.txt"' % list_name
+        response['Content-Disposition'] = 'attachment; filename="new_members.txt"'
     except Exception as e:
         response = HttpResponse('Error: %s' % e)
         response.status_code = 400

--- a/chameleon_mailman/views.py
+++ b/chameleon_mailman/views.py
@@ -1,5 +1,5 @@
 from chameleon_token.decorators import token_required
-from datetime import datetime
+from datetime import datetime, timedelta
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
 from django.contrib import messages
@@ -19,8 +19,11 @@ def mailman_export_list(request):
     users who joined in the last day.
     """
     try:
+        # Ignoring complexity of timezones because we just want a fuzzy range
+        # that is limited to a recent window
+        start_of_yesterday = datetime.today() - timedelta(days=1)
         users = get_user_model().objects.filter(is_active=True,
-                                                date_joined__gte=datetime.today())
+                                                date_joined__gte=start_of_yesterday)
         content = list(u.email for u in users)
         response = HttpResponse('\n'.join(content), content_type='text/plain')
         response['Content-Disposition'] = 'attachment; filename="new_members.txt"'


### PR DESCRIPTION
The new sync behavior will be to sync only members who have recently
signed up with Chameleon. This updates the sync endpoint to not be
list-specific, and also to only pull users who have joined since the
beginning of the day. As long as this runs once a day, we shouldn't miss
anybody.