### PR TITLE
pass webinars separately in view context

### DIFF
--- a/chameleon/templates/user_news/cms/plugin.html
+++ b/chameleon/templates/user_news/cms/plugin.html
@@ -1,26 +1,57 @@
 <div class="row">
-{% for news in news_list %}
-<div class="col-sm-6">
-  <article class="block news-item">
-    <header class="post-header">
-      <h2 title="{{ news.title }}">
-        <a href="{% url 'user_news:detail' news.slug %}">{{ news.title }}</a>
-      </h2>
-      {% if news.event.event_type == "WEBINAR" %}
-      <div class="meta">Event Date: {{ news.event.event_date|date:"F d, o" }}</div>
-      {% else %}
-      <div class="meta">{{news.event.event_type }} {{ news.created|date:"F d, o" }}</div>
-      {% endif %}
-    </header>
+  <div class="col-sm-6">
+    <h2>News</h2>
+    
+    {% for news in news_list %}
+      <article class="block news-item">
+        <header class="post-header">
+          <h2 title="{{ news.title }}">
+            <a href="{% url 'user_news:detail' news.slug %}">{{ news.title }}</a>
+          </h2>
+          <div class="meta">{{news.event.event_type }} {{ news.created|date:"F d, o" }}</div>
+        </header>
 
-    <section class="news-item-summary post-content">
-      {{ news.summary|safe }}
-    </section>
+        <section class="news-item-summary post-content">
+          {{ news.summary|safe }}
+        </section>
 
-    <div class="read-more">
-      <a href="{% url 'user_news:detail' news.slug %}" class="read-more-link">Read more</a>
+        <div class="read-more">
+          <a href="{% url 'user_news:detail' news.slug %}" class="read-more-link">Read more</a>
+        </div>
+
+      </article>
+    {% endfor %}
+
+    <div>
+      <a href="/news">Read the Latest News</a>
     </div>
-  </article>
-</div>
-{% endfor %}
+  </div>
+
+  <div class="col-sm-6">
+    <h2>Events</h2>
+
+    {% for event in events_list %}
+      <article class="block news-item">
+        <header class="post-header">
+          <h2 title="{{ event.title }}">
+            <a href="{% url 'user_news:detail' event.slug %}">{{ event.title }}</a>
+          </h2>
+          <div class="meta">Event Date: {{ event.event.event_date|date:"F d, o" }}</div>
+        </header>
+
+        <section class="news-item-summary post-content">
+          {{ event.summary|safe }}
+        </section>
+
+        <div class="read-more">
+          <a href="{% url 'user_news:detail' event.slug %}" class="read-more-link">Read more</a>
+        </div>
+      </article>
+    {% endfor %}
+
+    <div>
+      <a href="/news/events">View all Upcoming and Recent Events</a>
+    </div>
+  </div>
+
 </div>

--- a/user_news/cms_plugins.py
+++ b/user_news/cms_plugins.py
@@ -12,18 +12,12 @@ class UserNewsPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         context['instance'] = instance
-        queryset = News.objects.order_by('-created')
+        queryset = News.objects
+        news_items = queryset.filter(event__isnull=True).order_by('-created')
+        event_items = queryset.filter(event__isnull=False).order_by('-event__event_date')
 
-        if not instance.display_events:
-            queryset = queryset.filter(event__isnull=True)
-
-        if not instance.display_outages:
-            queryset = queryset.filter(outage__isnull=True)
-
-        if not instance.display_news:
-            queryset = queryset.exclude(outage__isnull=True, event__isnull=True)
-
-        context['news_list'] = queryset[:instance.limit]
+        context['news_list'] = news_items[:2]
+        context['events_list'] = event_items[:2]
 
         return context
 

--- a/user_news/urls.py
+++ b/user_news/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import patterns, include, url
 from django.core.urlresolvers import reverse_lazy
-from user_news.views import UserNewsListView, UserNewsDetailView, UserNewsRedirectView, UserNewsFeed, OutageListView, OutageDetailView, OutageFeed
+from user_news.views import UserEventsListView, UserNewsListView, UserNewsDetailView, UserNewsRedirectView, UserNewsFeed, OutageListView, OutageDetailView, OutageFeed
 
 urlpatterns = patterns('',
     url(r'^$', UserNewsListView.as_view(), name='list'),
     url(r'^rss/$', UserNewsFeed(), name='feed'),
+    url(r'^events/$', UserEventsListView.as_view(), name='events_list'),
 
     url(r'^outages/$', OutageListView.as_view(), name='outage_list'),
     url(r'^outages/rss/$', OutageFeed(), name='outage_feed'),

--- a/user_news/views.py
+++ b/user_news/views.py
@@ -7,6 +7,11 @@ from django.contrib.syndication.views import Feed
 from user_news.models import News, Event, Outage, OutageUpdate
 from cms.cms_toolbar import ADMIN_MENU_IDENTIFIER
 
+class UserEventsListView(ListView):
+    model = News
+    paginate_by = 10
+    queryset = News.objects.filter(event__isnull=False, outage__isnull=True).order_by('-event__event_date')
+
 class UserNewsListView(ListView):
     model = News
     paginate_by = 10


### PR DESCRIPTION
The goal of this change is two display two lists on the front page of the portal: one for News items and one for Events. Additionally, I added a route to display only Event items at `/news/events`, which is similar to how the `/news` route lists all News items and `/webinars` route lists all Webinars items.

---

**commits to get here:**

display news/webinars in two columns

order by event_date

remove comment

show events instead of only webinars

partition news into events and non-events

add links to news and events lists

add news/events/ route

add link to events list