### PR TITLE
Ensuring no redirect loop on form post

### DIFF
--- a/chameleon/templates/sso/keystone_login_unavailable.html
+++ b/chameleon/templates/sso/keystone_login_unavailable.html
@@ -7,10 +7,10 @@
 <div class="row">
   <div class="col-sm-6">
     <p>
-     A Chameleon project associated with your account was not found. If your account was recently updated with a project affiliation, please wait a few minutes for the account to update before trying again.
+     We've encountered an error accessing Horizon, please wait a few minutes and try again.
     </p>
     <p>
-     To create or join a project, please follow the steps <a href="https://chameleoncloud.readthedocs.io/en/latest/getting-started/index.html#step-2-create-or-join-a-project" target="_blank">here</a>.
+     If the issue persists, please contact the helpdesk at <a href="/user/help/">this link</a>.
     </p>
   </div>
 </div>

--- a/chameleon/templates/sso/keystone_project_not_found.html
+++ b/chameleon/templates/sso/keystone_project_not_found.html
@@ -1,0 +1,17 @@
+{% extends "layout/default.html" %}
+{% load bootstrap3 %}
+{% block title %}Account Error{% endblock %}
+{% block content %}
+<h1>No Chameleon Project Found</h1>
+
+<div class="row">
+  <div class="col-sm-6">
+    <p>
+     A Chameleon project associated with your account was not found. If your account was recently updated with a project affiliation, please wait a few minutes for the account to update before trying again.
+    </p>
+    <p>
+     To create or join a project, please follow the steps <a href="https://chameleoncloud.readthedocs.io/en/latest/getting-started/index.html#step-2-create-or-join-a-project" target="_blank">here</a>.
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/chameleon/urls.py
+++ b/chameleon/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     url(r'^login/', chameleon_os_login.custom_login, name='login'),
     url(r'^sso/horizon/$', chameleon_views.horizon_sso_login, name='horizon_sso_login'),
     url(r'^sso/horizon/unavailable', chameleon_views.horizon_sso_unavailable, name='horizon_sso_unavailable'),
+    url(r'^sso/horizon/noprojects', chameleon_views.no_project_found, name='no_project_found'),
     url(r'^logout/', logout, {'next_page': '/'}, name='logout'),
 
     url(r'^register/', RedirectView.as_view(permanent=True, url=reverse_lazy('tas:register'))),


### PR DESCRIPTION
I think the issue with login loop was caused when a token was retrieved successfully at the manual login form, but an error occurred when synchronizing projects. The error sent the user to `manual_ks_login(request)` where the function interpreted the request as a form submission so retrieved a new token and looped back to attempt project sync and login, causing a loop