### PR TITLE
Add support for editing given DOI

### DIFF
--- a/sharing_portal/urls.py
+++ b/sharing_portal/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r'^upload$', views.upload, name='upload'),
     url(r'^(?P<pk>\d+)$', views.DetailView.as_view(), name='detail'),
     url(r'^(?P<pk>\d+)/edit$', views.edit_artifact, name='edit'),
+    url(r'^edit$', views.edit_redirect, name='edit_redirect'),
 ]


### PR DESCRIPTION
The JupyterHub integration doesn't know about sharing portal IDs, nor
should it. However, it does know about DOIs, and we can use this allow
linking out to an edit page.

This adds a new route that will attempt to look up an artifact by DOI
and open its edit page.