### PR TITLE
Include interface/region in session adapter

### DIFF
--- a/chameleon/os_login.py
+++ b/chameleon/os_login.py
@@ -4,10 +4,9 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.conf import settings
 from django.contrib.auth.views import login
 import sys
-from keystoneclient import client as ks_client
-from keystoneclient.v3 import client as v3_ksclient
+from keystoneclient.v3 import client as ks_client
 from keystoneauth1.identity import v3
-from keystoneauth1 import session
+from keystoneauth1 import adapter, session
 from keystoneauth1.exceptions.http import NotFound as NotFoundException
 import time
 import logging
@@ -50,7 +49,8 @@ def update_ks_password(request):
         auth = v3.Password(auth_url=settings.OPENSTACK_KEYSTONE_URL,username=settings.OPENSTACK_SERVICE_USERNAME, password=settings.OPENSTACK_SERVICE_PASSWORD, \
             project_id=settings.OPENSTACK_SERVICE_PROJECT_ID, project_name='services', user_domain_id="default")
         sess = session.Session(auth=auth, timeout=5)
-        ks = v3_ksclient.Client(session=sess, region_name=settings.OPENSTACK_TACC_REGION)
+        sess = adapter.Adapter(sess, interface='public', region_name=settings.OPENSTACK_TACC_REGION)
+        ks = ks_client.Client(session=sess)
         user = filter(lambda this: this.name==request.POST.get('username'), ks.users.list())
         if user:
             ks.users.update(user=user[0], password=request.POST.get('password'))

--- a/chameleon/views.py
+++ b/chameleon/views.py
@@ -20,7 +20,7 @@ from django.contrib.auth.forms import AuthenticationForm
 from django.http import HttpResponseRedirect
 from keystoneclient.v3 import client as ks_client
 from keystoneauth1.identity import v3
-from keystoneauth1 import session as ks_session
+from keystoneauth1 import adapter, session
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
@@ -44,7 +44,8 @@ def horizon_sso_login(request):
     if unscoped_token:
         try:
             auth = v3.Token(auth_url=settings.OPENSTACK_KEYSTONE_URL, token=unscoped_token.get('auth_token'), project_id=None)
-            sess = ks_session.Session(auth=auth, timeout=5)
+            sess = session.Session(auth=auth, timeout=5)
+            sess = adapter.Adapter(sess, interface='public')
             ks = ks_client.Client(session=sess)
             active_ks_projects_found = user_has_active_ks_project(ks, request.user)
             logger.debug('User: ' + request.user.username + ' is attempting to log in to Horizon; active_keystone_projects_found: ' + str(active_ks_projects_found))

--- a/projects/views.py
+++ b/projects/views.py
@@ -20,9 +20,9 @@ from django.db import IntegrityError
 import re
 import logging
 import json
-from keystoneclient.v3 import client as v3_ksclient
+from keystoneclient.v3 import client as ks_client
 from keystoneauth1.identity import v3
-from keystoneauth1 import session
+from keystoneauth1 import adapter, session
 from django.conf import settings
 import uuid
 import sys
@@ -227,8 +227,8 @@ def get_admin_ks_client():
         password=settings.OPENSTACK_SERVICE_PASSWORD, \
         project_id=settings.OPENSTACK_SERVICE_PROJECT_ID, project_name='services', user_domain_id="default")
     sess = session.Session(auth=auth, timeout=5)
-    ks_client = v3_ksclient.Client(session=sess, region_name=settings.OPENSTACK_TACC_REGION)
-    return ks_client
+    sess = adapter.Adapter(sess, interface='public', region_name=settings.OPENSTACK_TACC_REGION)
+    return ks_client.Client(session=sess)
 
 def set_ks_project_nickname(chargeCode, nickname):
     ks = get_admin_ks_client()


### PR DESCRIPTION
When making calls to OpenStack via its clients, it's possible to pass in
a Session object, which contains the auth information and other params.
However, you can also pass in an Adapter, which wraps a session but
pre-fills a few things that would normally be specified per-call or
per-client-construction, such as which interface/region to use (which
endpoint).

This updates all of the keystone clients to use Adapters with
interface=public and region pre-filled (where applicable.)