### PR TITLE
Add outage email reminders

### DIFF
--- a/chameleon/__init__.py
+++ b/chameleon/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
+from chameleon.celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/chameleon/celery.py
+++ b/chameleon/celery.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, unicode_literals
+
+import os
+
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'chameleon.settings')
+
+from django.conf import settings
+
+app = Celery('chameleon')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -311,7 +311,7 @@ LOGGING = {
             'level': 'INFO',
         },
         'chameleon_cms_integrations': {
-            'handlers': ['console'], 
+            'handlers': ['console'],
             'level': 'INFO'
         },
         'chameleon_openid': {
@@ -630,3 +630,12 @@ PARLER_LANGUAGES = {
 # ref: https://github.com/divio/django-filer/issues/1031
 FILE_UPLOAD_MAX_MEMORY_SIZE = 10000000
 FILE_UPLOAD_PERMISSIONS = 0o644
+
+# OUTAGE EMAIL REMINDER
+
+CELERY_BROKER_URL = 'redis://redis:6379'
+CELERY_RESULT_BACKEND = 'redis://redis:6379'
+CELERY_ACCEPT_CONTENT = ['application/json']
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_TASK_SERIALIZER = 'json'
+OUTAGE_EMAIL_REMINDER_TIMEDELTA = (60 * 60 * 2)

--- a/chameleon_mailman/tasks.py
+++ b/chameleon_mailman/tasks.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, unicode_literals
+
+from celery import shared_task
+
+from django.core.mail import send_mail
+
+
+@shared_task
+def schedule_email(*args, **kwargs):
+    send_mail(*args, **kwargs)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,8 @@ services:
     command: python manage.py runserver 0.0.0.0:8888
     depends_on:
       - mysql
+      - redis
+      - mail
   referenceapi:
     image: referenceapi:latest
     ports:
@@ -38,3 +40,22 @@ services:
       - PMA_PORT=3306
     depends_on:
       - mysql
+  redis:
+    image: "redis:alpine"
+    expose:
+        - '6379'
+    ports:
+        - '6379:6379'
+  celery:
+    build: .
+    command: celery -A chameleon worker -l info
+    env_file:
+      - .chameleon_env
+    volumes:
+      - .:/project
+    depends_on:
+      - mysql
+      - redis
+  mail:
+    image: bytemark/smtp
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,18 @@ referenceapi:
   image: referenceapi:latest
   ports:
     - 8000:8000
+redis:
+  image: "redis:alpine"
+  expose:
+    - '6379'
+  ports:
+    - '6379:6379'
+celery:
+  build: .
+  command: celery -A chameleon worker -l info
+  env_file:
+    - .chameleon_env
+  volumes:
+    - .:/project
+  depends_on:
+    - redis

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -3,6 +3,7 @@ asn1crypto==0.24.0
 atomicwrites==1.3.0
 attrs==19.1.0
 Babel==2.7.0
+celery==4.2.1
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
@@ -73,6 +74,7 @@ jsonpatch==1.24
 jsonpointer==2.0
 jsonschema==3.0.2
 keystoneauth1==3.17.0
+kombu==4.2.1
 lxml==4.4.1
 markdown2==2.3.8
 mock==3.0.5
@@ -114,6 +116,7 @@ python-novaclient==11.0.0
 python-openid==2.2.5
 pytz==2019.2
 PyYAML==3.13
+redis==2.10.6
 requests==2.22.0
 responses==0.10.6
 rfc3986==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,9 @@ djangocms-text-ckeditor
 djangocms-video
 djangocms-blog
 
+celery
 httpretty
+kombu
 mock
 MySQL-python
 opbeat
@@ -33,6 +35,7 @@ ply
 python-openid
 pytz
 PyYAML
+redis
 requests
 rt
 six

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -38,3 +38,8 @@ python-novaclient===11.0.0
 python-blazarclient===2.0.1
 
 git+https://github.com/ChameleonCloud/pytas#egg=pytas
+
+# Celery requirements
+celery==4.2.1
+redis==2.10.6
+kombu==4.2.1

--- a/user_news/forms.py
+++ b/user_news/forms.py
@@ -12,6 +12,7 @@ class EventForm(ModelForm):
 
 class OutageForm(ModelForm):
     send_email_notification = BooleanField(required=False)
+    send_email_reminder = BooleanField(required=False)
 
     class Meta:
         model = Outage
@@ -20,4 +21,9 @@ class OutageForm(ModelForm):
     def clean_send_email_notification(self):
         send = self.cleaned_data.get('send_email_notification')
         self.instance.send_email_notification = send
+        return send
+
+    def clean_send_email_reminder(self):
+        send = self.cleaned_data.get('send_email_reminder')
+        self.instance.send_email_reminder = send
         return send

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -74,6 +74,7 @@ class Outage(News):
     end_date = models.DateTimeField('expected end of outage')
     resolved = models.BooleanField('resolved', default=False)
     send_email_notification = False
+    send_email_reminder = False
 
     SEVERITY_LEVEL = (
         ('',''),


### PR DESCRIPTION
Gives admins option to send outage email reminders by specified number of
seconds before outage (current set to 2 hours in settings file). This
required adding celery and redis as a broker and backend.