### PR TITLE
Use mapped projects/allocations only for fed users

### DIFF
--- a/util/project_allocation_mapper.py
+++ b/util/project_allocation_mapper.py
@@ -29,7 +29,7 @@ class ProjectAllocationMapper:
         self.current_user = request.user.username
 
     def _wants_db(self, request):
-        return request.user.is_superuser
+        return request.session.get('is_federated', False)
 
     def _send_allocation_request_notification(self, charge_code, host):
         subject = 'Pending allocation request for project {}'.format(charge_code)


### PR DESCRIPTION
Currently any user with the "superuser" status is exposed to the new
projects/allocations code. To make this easier to test, make it easy to
opt-in/opt-out by making it linked to federated vs. non-federated login
sessions.

Users can log in via federation at /oidc/authenticate