### PR TITLE
Add toggle for opting in globally to federation

### DIFF
--- a/chameleon/os_login.py
+++ b/chameleon/os_login.py
@@ -1,9 +1,12 @@
 from csp.decorators import csp_update
+from django.conf import settings
+from django.contrib.auth.views import login
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
-from django.conf import settings
-from django.contrib.auth.views import login
+
 from chameleon.keystone_auth import regenerate_tokens
 from sharing_portal.conf import JUPYTERHUB_URL
 
@@ -15,6 +18,9 @@ LOG = logging.getLogger(__name__)
 @csrf_protect
 @never_cache
 def custom_login(request, current_app=None, extra_context=None):
+    if request.COOKIES.get(settings.NEW_LOGIN_EXPERIENCE_COOKIE) == '1':
+        return HttpResponseRedirect(reverse('oidc_authentication_init'))
+
     login_return = login(request, current_app=None, extra_context=None)
     password = request.POST.get('password', False)
     if request.user.is_authenticated() and password:

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -722,3 +722,7 @@ CSP_SCRIPT_SRC = ["'self'", 'https://www.google-analytics.com/', "'unsafe-inline
 CSP_FONT_SRC = ["'self'", 'https://fonts.gstatic.com/']
 CSP_STYLE_SRC = ["'self'", 'https://fonts.googleapis.com/', "'unsafe-inline'"]
 CSP_INCLUDE_NONCE_IN=['script-src']
+
+
+# Federation new login experience
+NEW_LOGIN_EXPERIENCE_COOKIE = 'new_login_experience'

--- a/chameleon/urls.py
+++ b/chameleon/urls.py
@@ -38,6 +38,8 @@ urlpatterns = [
     url(r'^sso/horizon/unavailable', chameleon_views.horizon_sso_unavailable, name='horizon_sso_unavailable'),
     url(r'^logout/', logout, {'next_page': '/'}, name='logout'),
 
+    url(r'^new-login-experience/$', chameleon_views.new_login_experience, name='new_login_experience'),
+
     url(r'^register/', RedirectView.as_view(permanent=True, url=reverse_lazy('tas:register'))),
     url(r'^user/', include('tas.urls', namespace='tas')),
     url(r'^email-confirmation/', tas_views.email_confirmation),


### PR DESCRIPTION
Because it is possible to set cookies on all subdomains by using a
leading '.' on the cookie domain, we can effectively opt a user in to
all web properties via a single endpoint.

This also supports an opt-out flow.

To opt in, visit: /new-login-experience
To opt out, visit: /new-login-experience?opt-out