### PR TITLE
rochaa/memcached

### DIFF
--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -719,7 +719,7 @@ CELERY_BEAT_SCHEDULE = {
 CSP_FRAME_ANCESTORS = "'self'"  # Similar to X-Frame-Options: SAMEORIGIN
 CSP_SCRIPT_SRC = ["'self'", 'https://www.google-analytics.com/', "'unsafe-inline'"]
 CSP_FONT_SRC = ["'self'", 'https://fonts.gstatic.com/']
-CSP_IMG_SRC = ["'self'", '*.googleusercontent.com', "'unsafe-inline'"]
+CSP_IMG_SRC = ["'self'", '*.googleusercontent.com']
 CSP_STYLE_SRC = ["'self'", 'https://fonts.googleapis.com/', "'unsafe-inline'"]
 CSP_INCLUDE_NONCE_IN=['script-src']
 

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -719,6 +719,7 @@ CELERY_BEAT_SCHEDULE = {
 CSP_FRAME_ANCESTORS = "'self'"  # Similar to X-Frame-Options: SAMEORIGIN
 CSP_SCRIPT_SRC = ["'self'", 'https://www.google-analytics.com/', "'unsafe-inline'"]
 CSP_FONT_SRC = ["'self'", 'https://fonts.gstatic.com/']
+CSP_IMG_SRC = ["'self'", '*.googleusercontent.com', "'unsafe-inline'"]
 CSP_STYLE_SRC = ["'self'", 'https://fonts.googleapis.com/', "'unsafe-inline'"]
 CSP_INCLUDE_NONCE_IN=['script-src']
 

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -725,3 +725,10 @@ CSP_INCLUDE_NONCE_IN=['script-src']
 
 # Federation new login experience
 NEW_LOGIN_EXPERIENCE_COOKIE = 'new_login_experience'
+
+CACHES = {
+    'default': {
+        'BACKEND': os.environ.get('CACHE_BACKEND', 'django.core.cache.backends.locmem.LocMemCache'),
+        'LOCATION': os.environ.get('CACHE_LOCATION', 'LOC_MEM_CACHE'),
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ sqlparse
 pytas
 bibtexparser
 mozilla-django-oidc
-
+python-memcached
 python-glanceclient
 python-keystoneclient
 python-novaclient

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -32,7 +32,7 @@ PyYAML~=3.12
 django-formtools==2.1
 mozilla-django-oidc<1.3
 bibtexparser<1.2.0
-
+python-memcached~=1.59
 # Copied from openstack/requirements@stable/rocky
 python-glanceclient==2.13.1
 python-keystoneclient==3.17.0

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -8,6 +8,7 @@ django-bootstrap3~=11.0
 django-ckeditor~=5.3.0
 django-classy-tags~=0.8.0
 django-cms~=3.6.0
+django-filer<2.0.0
 djangocms-attributes-field~=1.0.0
 git+https://github.com/ChameleonCloud/djangocms-blog@chameleon/1.0.x#egg=djangocms_blog
 djangocms-file~=2.3.0

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -8,7 +8,6 @@ django-bootstrap3~=11.0
 django-ckeditor~=5.3.0
 django-classy-tags~=0.8.0
 django-cms~=3.6.0
-django-filer<2.0.0
 djangocms-attributes-field~=1.0.0
 git+https://github.com/ChameleonCloud/djangocms-blog@chameleon/1.0.x#egg=djangocms_blog
 djangocms-file~=2.3.0


### PR DESCRIPTION
adding memcached option, also setting django-filer version to one supported by python 2, recent changes made python3.5 minimum for the latest version of django-filer, https://pypi.org/project/django-filer/