### PR TITLE
fix issue of listing random users in a project

### DIFF
--- a/util/project_allocation_mapper.py
+++ b/util/project_allocation_mapper.py
@@ -282,6 +282,10 @@ class ProjectAllocationMapper:
         # we have stopped writing any data to TAS for projects/allocations/
         # memberships.
         usernames = [u.username for u in users]
+        # The project id might be portal id.
+        # To avoid getting random users, get actual tas project using charge code.
+        tas_proj_id = self.get_attr(self._tas_lookup_project(tas_project.chargeCode), 'id')
+        tas_project = self.set_attr(tas_project, 'id', tas_proj_id)
         for tas_user in tas_project.get_users():
             if tas_user.username not in usernames:
                 users.append(tas_user)


### PR DESCRIPTION
When we get a project from portal, although we switch the project as TAS Project object, we keep the portal project id. But this will mess up getting members of a project https://github.com/ChameleonCloud/portal/blob/master/util/project_allocation_mapper.py#L285-L287. 