### PR TITLE
improve admin projects/allocations loading

### DIFF
--- a/allocations/models.py
+++ b/allocations/models.py
@@ -28,27 +28,3 @@ class Allocation(models.Model):
     start_date = models.DateTimeField(null=True)
     su_allocated = models.FloatField(null=True)
     su_used = models.FloatField(null=True)
-    
-    def requestor_username(self):
-        if self.requestor:
-            return self.requestor.username
-        else:
-            return None
-
-    def requestor_id(self):
-        if self.requestor:
-            return self.requestor.id
-        else:
-            return None
-    
-    def reviewer_username(self):
-        if self.reviewer:
-            return self.reviewer.username
-        else:
-            return None
-    
-    def reviewer_id(self):
-        if self.reviewer:
-            return self.reviewer.id
-        else:
-            return None

--- a/projects/models.py
+++ b/projects/models.py
@@ -25,25 +25,6 @@ class Project(models.Model):
     nickname = models.CharField(max_length=255,blank=False,unique=True)
     field = models.ForeignKey(Field,related_name='project_field',null=True)
     charge_code = models.CharField(max_length=50,blank=False)
-    
-    def type_id(self):
-        return self.type.id
-    
-    def type_name(self):
-        return self.type.name
-    
-    def field_id(self):
-        if self.field:
-            return self.field.id
-        return None
-    
-    def field_name(self):
-        if self.field:
-            return self.field.name
-        return None
-    
-    def pi_id(self):
-        return self.pi.id
 
 class ProjectExtras(models.Model):
     tas_project_id = models.IntegerField(primary_key=True)


### PR DESCRIPTION
Loading all projects/allocations is slow in admin page. The cause of the
slowness is due to the django model foreign key lazy load. To improve the
performace, django "select_related" is used. The django "select_related"
is a performance booster which results in a single more complex query but
means later use of foreign-key relationships won’t require database queries.

Read https://docs.djangoproject.com/en/2.2/ref/models/querysets/#select-related
for more information.