### PR TITLE
show user metadata in pi eligibility review page and profile page

### DIFF
--- a/chameleon/admin.py
+++ b/chameleon/admin.py
@@ -3,6 +3,8 @@ from functools import wraps
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth import get_user_model
 from chameleon.models import PIEligibility
+from util.keycloak_client import KeycloakClient
+import re
 
 def add_method(cls):
     def decorator(func):
@@ -21,12 +23,30 @@ def pi_eligibility(self):
         return 'Ineligible'
 
 class PIEligibilityAdmin(admin.ModelAdmin):
-    readonly_fields = ['requestor','request_date','reviewer','review_date']
-    fields = ('requestor','request_date','status','review_date','reviewer','review_summary')
+    readonly_fields = ['requestor','request_date','user_metadata', 'reviewer','review_date']
+    fields = ('requestor','request_date','user_metadata','status','review_date','reviewer','review_summary')
     ordering = ['-status','-request_date','-review_date']
 
     list_display = ('requestor','status','request_date')
     list_filter = ('status',)
     search_fields = ['requestor__username']
+
+    def user_metadata(self, obj):
+        keycloak_client = KeycloakClient()
+        keycloak_user = keycloak_client.get_keycloak_user_by_username(obj.requestor.username)
+
+        if not keycloak_user:
+            return None
+
+        full_name = '{} {}'.format(keycloak_user['lastName'], keycloak_user['firstName'])
+        email = keycloak_user['email']
+        contents = [f'Name: {full_name}', f'Email: {email}']
+        for key, val in keycloak_user['attributes'].items():
+            if key not in ['joinDate']:
+                #convert camelcase to separate out words
+                key = re.sub("([A-Z])", " \\1", key).strip().capitalize()
+                contents.append(f'{key}: {val}')
+
+        return '\n'.join(contents)
 
 admin.site.register(PIEligibility, PIEligibilityAdmin)

--- a/tas/views.py
+++ b/tas/views.py
@@ -21,30 +21,16 @@ from djangoRT import rtUtil, rtModels
 import re
 import logging
 import json
+from util.project_allocation_mapper import ProjectAllocationMapper
 
 logger = logging.getLogger(__name__)
 
 @login_required
 def profile(request):
     context = {}
-    if request.session.get('is_federated', False):
-            context['piEligibility'] = request.user.pi_eligibility()
-            profile = {}
-            profile['firstName'] = request.user.first_name
-            profile['lastName'] = request.user.last_name
-            profile['email'] = request.user.email
-            context['profile'] = profile
-            return render(request, 'tas/profile.html', context)
-    try:
-        tas = TASClient()
-        resp = tas.get_user(username=request.user)
-        context['profile'] = resp
-        if request.session.get('is_federated', False):
-            context['piEligibility'] = request.user.pi_eligibility()
-        else:
-            context['piEligibility'] = resp['piEligibility']
-    except:
-        context['profile'] = False
+    mapper = ProjectAllocationMapper(request)
+    context['profile'] = mapper.get_user(request.user)
+    context['piEligibility'] = context['profile']['piEligibility']
 
     return render(request, 'tas/profile.html', context)
 

--- a/util/keycloak_client.py
+++ b/util/keycloak_client.py
@@ -88,7 +88,12 @@ class KeycloakClient:
         )
         matching = [u for u in matching if u['username'] == username]
         if matching and len(matching) == 1:
-            return matching[0]
+            user = matching[0]
+            # normalize attributes
+            for key, val in user['attributes'].items():
+                if type(val) is list and len(val) == 1:
+                    user['attributes'][key] = val[0]
+            return user
         else:
             return None
 

--- a/util/project_allocation_mapper.py
+++ b/util/project_allocation_mapper.py
@@ -556,6 +556,7 @@ class ProjectAllocationMapper:
             pi_eligibility = user.pi_eligibility()
         except:
             pi_eligibility = 'Ineligible'
+
         tas_user = {'username': user.username,
                     'firstName': user.first_name,
                     'lastName': user.last_name,
@@ -570,8 +571,21 @@ class ProjectAllocationMapper:
                     'department': None,
                     'institution': None,
                     'role': role}
-        return tas_user
 
+        keycloak_client = KeycloakClient()
+        keycloak_user = keycloak_client.get_keycloak_user_by_username(user.username)
+
+        if keycloak_user:
+            attrs = keycloak_user['attributes']
+            tas_user.update({
+                'institution': attrs.get('affiliationInstitution', None),
+                'department': attrs.get('affiliationDepartment', None),
+                'title': attrs.get('affiliationTitle', None),
+                'country': attrs.get('country', None),
+                'phone': attrs.get('phone', None),
+                'citizenship': attrs.get('citizenship', None)})
+
+        return tas_user
 
     def get_attr(self, obj, key):
         '''Attempt to resolve the key either as an attribute or a dict key'''


### PR DESCRIPTION
Portal doesn't store all metadata of a user. To provide the user
information for pi eligibility reviewers and to show profile in the user
dashboard, we fetch user metadata from Keycloak.