### PR TITLE
Fix issues requesting PI eligibility

### DIFF
--- a/tas/forms.py
+++ b/tas/forms.py
@@ -36,32 +36,261 @@ USER_PROFILE_TITLES = (
     ('University Research Staff', 'University Research Staff (excluding postdoctorates)'),
 )
 
-def get_institution_choices():
-    tas = TASClient()
-    institutions_list = tas.institutions()
-    return (('', 'Choose one'),) + tuple((c['name'], c['name']) for c in institutions_list)
-
-
-def get_department_choices(institution):
-    tas = TASClient()
-    institutions_list = tas.institutions()
-    institution_id = None
-    for inst in institutions_list:
-        if inst['name'] == institution:
-            institution_id = inst['id']
-            break
-    if institution_id:
-        departments_list = tas.get_departments(institution_id)
-        if len(departments_list) == 0:
-            return None
-        return (('', 'Choose one'),) + tuple((c['name'], c['name']) for c in departments_list)
-    else:
-        return None
-
-def get_country_choices():
-    tas = TASClient()
-    countries_list = tas.countries()
-    return (('', 'Choose one'),) + tuple((c['name'], c['name']) for c in countries_list)
+# ISO-3166 list; this matches what is in the keycloak-chameleon extension.
+# TODO(jason): pull this list from an endpoint exposed by Keycloak? Hard to keep
+# this in sync (but how often do new countries come around?)
+COUNTRY_LIST = (
+    ('', 'Choose one'),
+    ('Afghanistan', 'Afghanistan'),
+    ('Åland Islands', 'Åland Islands'),
+    ('Albania', 'Albania'),
+    ('Algeria', 'Algeria'),
+    ('American Samoa', 'American Samoa'),
+    ('Andorra', 'Andorra'),
+    ('Angola', 'Angola'),
+    ('Anguilla', 'Anguilla'),
+    ('Antarctica', 'Antarctica'),
+    ('Antigua and Barbuda', 'Antigua and Barbuda'),
+    ('Argentina', 'Argentina'),
+    ('Armenia', 'Armenia'),
+    ('Aruba', 'Aruba'),
+    ('Australia', 'Australia'),
+    ('Austria', 'Austria'),
+    ('Azerbaijan', 'Azerbaijan'),
+    ('Bahamas', 'Bahamas'),
+    ('Bahrain', 'Bahrain'),
+    ('Bangladesh', 'Bangladesh'),
+    ('Barbados', 'Barbados'),
+    ('Belarus', 'Belarus'),
+    ('Belgium', 'Belgium'),
+    ('Belize', 'Belize'),
+    ('Benin', 'Benin'),
+    ('Bermuda', 'Bermuda'),
+    ('Bhutan', 'Bhutan'),
+    ('Bolivia (Plurinational State of)', 'Bolivia (Plurinational State of)'),
+    ('Bonaire, Sint Eustatius and Saba', 'Bonaire, Sint Eustatius and Saba'),
+    ('Bosnia and Herzegovina', 'Bosnia and Herzegovina'),
+    ('Botswana', 'Botswana'),
+    ('Bouvet Island', 'Bouvet Island'),
+    ('Brazil', 'Brazil'),
+    ('British Indian Ocean Territory', 'British Indian Ocean Territory'),
+    ('Brunei Darussalam', 'Brunei Darussalam'),
+    ('Bulgaria', 'Bulgaria'),
+    ('Burkina Faso', 'Burkina Faso'),
+    ('Burundi', 'Burundi'),
+    ('Cabo Verde', 'Cabo Verde'),
+    ('Cambodia', 'Cambodia'),
+    ('Cameroon', 'Cameroon'),
+    ('Canada', 'Canada'),
+    ('Cayman Islands', 'Cayman Islands'),
+    ('Central African Republic', 'Central African Republic'),
+    ('Chad', 'Chad'),
+    ('Chile', 'Chile'),
+    ('China', 'China'),
+    ('Christmas Island', 'Christmas Island'),
+    ('Cocos (Keeling) Islands', 'Cocos (Keeling) Islands'),
+    ('Colombia', 'Colombia'),
+    ('Comoros', 'Comoros'),
+    ('Congo', 'Congo'),
+    ('Congo, Democratic Republic of the', 'Congo, Democratic Republic of the'),
+    ('Cook Islands', 'Cook Islands'),
+    ('Costa Rica', 'Costa Rica'),
+    ('Côte d\'Ivoire', 'Côte d\'Ivoire'),
+    ('Croatia', 'Croatia'),
+    ('Cuba', 'Cuba'),
+    ('Curaçao', 'Curaçao'),
+    ('Cyprus', 'Cyprus'),
+    ('Czechia', 'Czechia'),
+    ('Denmark', 'Denmark'),
+    ('Djibouti', 'Djibouti'),
+    ('Dominica', 'Dominica'),
+    ('Dominican Republic', 'Dominican Republic'),
+    ('Ecuador', 'Ecuador'),
+    ('Egypt', 'Egypt'),
+    ('El Salvador', 'El Salvador'),
+    ('Equatorial Guinea', 'Equatorial Guinea'),
+    ('Eritrea', 'Eritrea'),
+    ('Estonia', 'Estonia'),
+    ('Eswatini', 'Eswatini'),
+    ('Ethiopia', 'Ethiopia'),
+    ('Falkland Islands (Malvinas)', 'Falkland Islands (Malvinas)'),
+    ('Faroe Islands', 'Faroe Islands'),
+    ('Fiji', 'Fiji'),
+    ('Finland', 'Finland'),
+    ('France', 'France'),
+    ('French Guiana', 'French Guiana'),
+    ('French Polynesia', 'French Polynesia'),
+    ('French Southern Territories', 'French Southern Territories'),
+    ('Gabon', 'Gabon'),
+    ('Gambia', 'Gambia'),
+    ('Georgia', 'Georgia'),
+    ('Germany', 'Germany'),
+    ('Ghana', 'Ghana'),
+    ('Gibraltar', 'Gibraltar'),
+    ('Greece', 'Greece'),
+    ('Greenland', 'Greenland'),
+    ('Grenada', 'Grenada'),
+    ('Guadeloupe', 'Guadeloupe'),
+    ('Guam', 'Guam'),
+    ('Guatemala', 'Guatemala'),
+    ('Guernsey', 'Guernsey'),
+    ('Guinea', 'Guinea'),
+    ('Guinea-Bissau', 'Guinea-Bissau'),
+    ('Guyana', 'Guyana'),
+    ('Haiti', 'Haiti'),
+    ('Heard Island and McDonald Islands', 'Heard Island and McDonald Islands'),
+    ('Holy See', 'Holy See'),
+    ('Honduras', 'Honduras'),
+    ('Hong Kong', 'Hong Kong'),
+    ('Hungary', 'Hungary'),
+    ('Iceland', 'Iceland'),
+    ('India', 'India'),
+    ('Indonesia', 'Indonesia'),
+    ('Iran (Islamic Republic of)', 'Iran (Islamic Republic of)'),
+    ('Iraq', 'Iraq'),
+    ('Ireland', 'Ireland'),
+    ('Isle of Man', 'Isle of Man'),
+    ('Israel', 'Israel'),
+    ('Italy', 'Italy'),
+    ('Jamaica', 'Jamaica'),
+    ('Japan', 'Japan'),
+    ('Jersey', 'Jersey'),
+    ('Jordan', 'Jordan'),
+    ('Kazakhstan', 'Kazakhstan'),
+    ('Kenya', 'Kenya'),
+    ('Kiribati', 'Kiribati'),
+    ('Korea (Democratic People\'s Republic of)', 'Korea (Democratic People\'s Republic of)'),
+    ('Korea, Republic of', 'Korea, Republic of'),
+    ('Kuwait', 'Kuwait'),
+    ('Kyrgyzstan', 'Kyrgyzstan'),
+    ('Lao People\'s Democratic Republic', 'Lao People\'s Democratic Republic'),
+    ('Latvia', 'Latvia'),
+    ('Lebanon', 'Lebanon'),
+    ('Lesotho', 'Lesotho'),
+    ('Liberia', 'Liberia'),
+    ('Libya', 'Libya'),
+    ('Liechtenstein', 'Liechtenstein'),
+    ('Lithuania', 'Lithuania'),
+    ('Luxembourg', 'Luxembourg'),
+    ('Macao', 'Macao'),
+    ('Madagascar', 'Madagascar'),
+    ('Malawi', 'Malawi'),
+    ('Malaysia', 'Malaysia'),
+    ('Maldives', 'Maldives'),
+    ('Mali', 'Mali'),
+    ('Malta', 'Malta'),
+    ('Marshall Islands', 'Marshall Islands'),
+    ('Martinique', 'Martinique'),
+    ('Mauritania', 'Mauritania'),
+    ('Mauritius', 'Mauritius'),
+    ('Mayotte', 'Mayotte'),
+    ('Mexico', 'Mexico'),
+    ('Micronesia (Federated States of)', 'Micronesia (Federated States of)'),
+    ('Moldova, Republic of', 'Moldova, Republic of'),
+    ('Monaco', 'Monaco'),
+    ('Mongolia', 'Mongolia'),
+    ('Montenegro', 'Montenegro'),
+    ('Montserrat', 'Montserrat'),
+    ('Morocco', 'Morocco'),
+    ('Mozambique', 'Mozambique'),
+    ('Myanmar', 'Myanmar'),
+    ('Namibia', 'Namibia'),
+    ('Nauru', 'Nauru'),
+    ('Nepal', 'Nepal'),
+    ('Netherlands', 'Netherlands'),
+    ('New Caledonia', 'New Caledonia'),
+    ('New Zealand', 'New Zealand'),
+    ('Nicaragua', 'Nicaragua'),
+    ('Niger', 'Niger'),
+    ('Nigeria', 'Nigeria'),
+    ('Niue', 'Niue'),
+    ('Norfolk Island', 'Norfolk Island'),
+    ('North Macedonia', 'North Macedonia'),
+    ('Northern Mariana Islands', 'Northern Mariana Islands'),
+    ('Norway', 'Norway'),
+    ('Oman', 'Oman'),
+    ('Pakistan', 'Pakistan'),
+    ('Palau', 'Palau'),
+    ('Palestine, State of', 'Palestine, State of'),
+    ('Panama', 'Panama'),
+    ('Papua New Guinea', 'Papua New Guinea'),
+    ('Paraguay', 'Paraguay'),
+    ('Peru', 'Peru'),
+    ('Philippines', 'Philippines'),
+    ('Pitcairn', 'Pitcairn'),
+    ('Poland', 'Poland'),
+    ('Portugal', 'Portugal'),
+    ('Puerto Rico', 'Puerto Rico'),
+    ('Qatar', 'Qatar'),
+    ('Réunion', 'Réunion'),
+    ('Romania', 'Romania'),
+    ('Russian Federation', 'Russian Federation'),
+    ('Rwanda', 'Rwanda'),
+    ('Saint Barthélemy', 'Saint Barthélemy'),
+    ('Saint Helena, Ascension and Tristan da Cunha', 'Saint Helena, Ascension and Tristan da Cunha'),
+    ('Saint Kitts and Nevis', 'Saint Kitts and Nevis'),
+    ('Saint Lucia', 'Saint Lucia'),
+    ('Saint Martin (French part)', 'Saint Martin (French part)'),
+    ('Saint Pierre and Miquelon', 'Saint Pierre and Miquelon'),
+    ('Saint Vincent and the Grenadines', 'Saint Vincent and the Grenadines'),
+    ('Samoa', 'Samoa'),
+    ('San Marino', 'San Marino'),
+    ('Sao Tome and Principe', 'Sao Tome and Principe'),
+    ('Saudi Arabia', 'Saudi Arabia'),
+    ('Senegal', 'Senegal'),
+    ('Serbia', 'Serbia'),
+    ('Seychelles', 'Seychelles'),
+    ('Sierra Leone', 'Sierra Leone'),
+    ('Singapore', 'Singapore'),
+    ('Sint Maarten (Dutch part)', 'Sint Maarten (Dutch part)'),
+    ('Slovakia', 'Slovakia'),
+    ('Slovenia', 'Slovenia'),
+    ('Solomon Islands', 'Solomon Islands'),
+    ('Somalia', 'Somalia'),
+    ('South Africa', 'South Africa'),
+    ('South Georgia and the South Sandwich Islands', 'South Georgia and the South Sandwich Islands'),
+    ('South Sudan', 'South Sudan'),
+    ('Spain', 'Spain'),
+    ('Sri Lanka', 'Sri Lanka'),
+    ('Sudan', 'Sudan'),
+    ('Suriname', 'Suriname'),
+    ('Svalbard and Jan Mayen', 'Svalbard and Jan Mayen'),
+    ('Sweden', 'Sweden'),
+    ('Switzerland', 'Switzerland'),
+    ('Syrian Arab Republic', 'Syrian Arab Republic'),
+    ('Taiwan, Province of China', 'Taiwan, Province of China'),
+    ('Tajikistan', 'Tajikistan'),
+    ('Tanzania, United Republic of', 'Tanzania, United Republic of'),
+    ('Thailand', 'Thailand'),
+    ('Timor-Leste', 'Timor-Leste'),
+    ('Togo', 'Togo'),
+    ('Tokelau', 'Tokelau'),
+    ('Tonga', 'Tonga'),
+    ('Trinidad and Tobago', 'Trinidad and Tobago'),
+    ('Tunisia', 'Tunisia'),
+    ('Turkey', 'Turkey'),
+    ('Turkmenistan', 'Turkmenistan'),
+    ('Turks and Caicos Islands', 'Turks and Caicos Islands'),
+    ('Tuvalu', 'Tuvalu'),
+    ('Uganda', 'Uganda'),
+    ('Ukraine', 'Ukraine'),
+    ('United Arab Emirates', 'United Arab Emirates'),
+    ('United Kingdom of Great Britain and Northern Ireland', 'United Kingdom of Great Britain and Northern Ireland'),
+    ('United States of America', 'United States of America'),
+    ('United States Minor Outlying Islands', 'United States Minor Outlying Islands'),
+    ('Uruguay', 'Uruguay'),
+    ('Uzbekistan', 'Uzbekistan'),
+    ('Vanuatu', 'Vanuatu'),
+    ('Venezuela (Bolivarian Republic of)', 'Venezuela (Bolivarian Republic of)'),
+    ('Viet Nam', 'Viet Nam'),
+    ('Virgin Islands (British)', 'Virgin Islands (British)'),
+    ('Virgin Islands (U.S.)', 'Virgin Islands (U.S.)'),
+    ('Wallis and Futuna', 'Wallis and Futuna'),
+    ('Western Sahara', 'Western Sahara'),
+    ('Yemen', 'Yemen'),
+    ('Zambia', 'Zambia'),
+    ('Zimbabwe', 'Zimbabwe'),
+)
 
 
 class EmailConfirmationForm(forms.Form):
@@ -159,37 +388,54 @@ class UserProfileForm(forms.Form):
     firstName = forms.CharField(label='First name')
     lastName = forms.CharField(label='Last name')
     email = forms.EmailField()
-    phone = forms.CharField()
-    institution = forms.ChoiceField(label='Institution', choices=(), error_messages={'invalid': 'Please select your affiliated institution'})
-    department = forms.ChoiceField(label='Department', choices=(), required=False)
-    title = forms.ChoiceField(label='Position/Title', choices=USER_PROFILE_TITLES)
-    country = forms.ChoiceField(label='Country of residence', choices=(), error_messages={'invalid': 'Please select your Country of residence'})
-    citizenship = forms.CharField(label='Country of citizenship', widget=forms.HiddenInput(), error_messages={'invalid': 'Please select your Country of citizenship'})
-    
+    phone = forms.CharField(required=False, error_messages={
+        'invalid': (
+            'For security reasons, we require all PIs have a contact '
+            'phone number registered.'),
+    })
+    institution = forms.CharField(label='Institution', error_messages={
+        'invalid': 'Please select your affiliated institution',
+    })
+    department = forms.CharField(label='Department', required=False)
+    title = forms.ChoiceField(label='Position/Title', required=False,
+        choices=USER_PROFILE_TITLES)
+    country = forms.ChoiceField(label='Country of residence', required=False,
+        choices=COUNTRY_LIST, error_messages={
+            'invalid': 'Please select your country of residence.',
+        })
+    citizenship = forms.ChoiceField(label='Country of citizenship', required=False,
+        choices=COUNTRY_LIST, error_messages={
+            'invalid': 'Please select your country of citizenship.',
+        })
+
     disabled_fields = ['firstName', 'lastName', 'email']
-    # tas returns empty department list for some institutions
-    fields_not_required_for_pi = ['department']
+    required_for_pi = ['phone', 'institution', 'country', 'citizenship']
 
     def __init__(self, *args, **kwargs):
-        is_pi_eligible = kwargs.pop('is_pi_eligible', False)
+        pi_eligibility_requested = kwargs.pop('is_pi_eligible', False)
         super(UserProfileForm, self).__init__(*args, **kwargs)
-        self.fields['institution'].choices = get_institution_choices()
-        data = self.data or self.initial
-        if (data is not None and 'institution' in data and data['institution']):
-            department_choices = get_department_choices(data['institution'])
-            if department_choices:
-                self.fields['department'].choices = department_choices
-        for field in self.fields:
-            if field in self.disabled_fields:
-                self.fields[field].widget.attrs['readonly'] = True
-            self.fields[field].required = False
-        self.fields['country'].choices = get_country_choices()
-        self.fields['citizenship'].widget.attrs['readonly'] = True
-        
-        if is_pi_eligible:
-            for field in self.fields:
-                if field not in self.disabled_fields and field not in self.fields_not_required_for_pi:
-                    self.fields[field].required = True
+
+        for field in self.disabled_fields:
+            self.fields[field].widget.attrs['readonly'] = True
+            self.fields[field].disabled = True
+
+        if pi_eligibility_requested:
+            for field in self.required_for_pi:
+                self.fields[field].required = True
+
+        # Prevent users from editing citizenship if  already set
+        # Ensure this comes after we set fields to required! We have to
+        # explicitly set this field to not required for it to pass validation
+        # due to using 'disabled' to prevent overwrites.
+        if self.initial.get('citizenship'):
+            citizenship_field = self.fields['citizenship']
+            citizenship_field.widget.attrs['readonly'] = True
+            citizenship_field.disabled = True
+            citizenship_field.required = False
+            citizenship_field.help_text = (
+                'Please file a support ticket if you need to update your '
+                'citizenship on file.')
+
 
 class TasUserProfileAdminForm(forms.Form):
     """

--- a/tas/templates/tas/profile_edit.html
+++ b/tas/templates/tas/profile_edit.html
@@ -9,10 +9,6 @@
     <form method="post">
       {% csrf_token %}
       {% bootstrap_form form %}
-          <p class="help-block">
-            <div style="font-weight: bold;">Citizenship</div>
-            Changes to citizenship information may be initiated via a support request <a href="/user/help/ticket/new/">here</a>
-          </p>
       <div class="form-group">
         <label>PI Eligibility</label>
         {% if piEligibility|lower == 'eligible' %}


### PR DESCRIPTION
- If the user did not have citizenship defined, the form would fail b/c
  this was a required field but the user could not edit

To fix this, this overhauls the edit form. We now handle empty
citizenship and ask the user here. There were issues mapping Keycloak
countries to the TAS list; drop the TAS list and settle on ISO-3166,
which is used in the Keycloak form. Also stop asking for institutions
and departments, which could not match anymore.