### PR TITLE
Add html_message kwarg to outage reminder mail.

### DIFF
--- a/chameleon_mailman/tasks.py
+++ b/chameleon_mailman/tasks.py
@@ -36,8 +36,8 @@ def send_outage_reminders(crontab_frequency, send_outage_reminder_before):
             sender = settings.DEFAULT_FROM_EMAIL
             recipients = settings.OUTAGE_NOTIFICATION_EMAIL.split(',')
 
-            mail_sent = send_mail(
-                subject, strip_tags(body), sender, recipients)
+            mail_sent = send_mail(subject, strip_tags(body), sender,
+                                  recipients, html_message=body)
 
             if mail_sent:
                 outage.reminder_sent = now


### PR DESCRIPTION
Outage reminder emails were being sent without html formatting.
This was because only plain_text was being passed to django's
send_mail function. To preserve html formatting for the email
message the message body should be passed to html_message kwarg.