### PR TITLE
Enable managing artifact labels

### DIFF
--- a/sharing_portal/forms.py
+++ b/sharing_portal/forms.py
@@ -5,29 +5,10 @@ from projects.models import Project
 from .models import Artifact, ArtifactVersion, Author, Label
 
 
-class LabelForm(forms.Form):
-    """
-    Form to allow search on the index page
-    """
-
-    class LabelChoiceField(forms.ModelChoiceField):
-        """
-        Custom model choice field that can display a choice
-        of existing Label models.
-        """
-        def label_from_instance(self, obj):
-            return str(obj.id)
-
-    search = forms.CharField(required=False)
-    labels = LabelChoiceField(label='Labels', required=False,
-                              queryset=Label.objects.all())
-    is_or = forms.BooleanField(required=False)
-
-
 class ArtifactForm(forms.ModelForm):
     class Meta:
         model = Artifact
-        fields = ('title', 'short_description', 'description',)
+        fields = ('title', 'short_description', 'description', 'labels',)
 
 
 class ArtifactVersionForm(forms.ModelForm):

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -459,6 +459,8 @@ def _handle_artifact_forms(request, artifact_form, authors_formset=None,
             if version:
                 version.artifact = artifact
                 version.save()
+            # Save the labels
+            artifact_form.save_m2m()
     else:
         errors.extend(artifact_form.errors)
 


### PR DESCRIPTION
This updates the edit UI to allow updating artifact labels. These labels
can be updated either within the embedded Jupyter edit form or on Trovi.
This functionality already existed, but was never surfaced to the user.