### PR TITLE
pin referenceapi to latest version from jenkins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - mysql
   referenceapi:
-    image: docker.chameleoncloud.org/referenceapi:latest
+    image: docker.chameleoncloud.org/referenceapi:fa7c701
     ports:
       - 127.0.0.1:8891:8000
   mysql:


### PR DESCRIPTION
pinned the referenceapi version to the current jenkins build.
the tag "latest" does not exist in the registry.

`https://docker.chameleoncloud.org/v2/referenceapi/tags/list?`