### PR TITLE
Enable automatic linting

### DIFF
--- a/.github/actions/yamllint.yml
+++ b/.github/actions/yamllint.yml
@@ -1,0 +1,8 @@
+# This is my first, very own configuration file for yamllint!
+# It extends the default conf by adjusting some options.
+
+extends: default
+
+rules:
+  truthy:
+    check-keys: false

--- a/.github/workflows/lint-ansible.yml
+++ b/.github/workflows/lint-ansible.yml
@@ -1,0 +1,14 @@
+---
+name: reviewdog
+on:
+  pull_request:
+    branches: main
+jobs:
+  ansiblelint:
+    name: ansible-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-ansiblelint@v1
+        with:
+          github_token: ${{ secrets.github_token }}

--- a/.github/workflows/lint-ansible.yml
+++ b/.github/workflows/lint-ansible.yml
@@ -5,7 +5,7 @@ on:
     branches: main
 jobs:
   ansiblelint:
-    name: ansible-lint
+    name: runner / ansiblelint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -1,0 +1,12 @@
+---
+name: reviewdog
+on: [pull_request]
+jobs:
+  hadolint:
+    name: runner / hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-hadolint@v1
+        with:
+          github_token: ${{ secrets.github_token }}

--- a/.github/workflows/lint-javascript.yml
+++ b/.github/workflows/lint-javascript.yml
@@ -1,0 +1,15 @@
+---
+name: reviewdog
+on:
+  pull_request:
+    branches: main
+jobs:
+  eslint:
+    name: runner / eslint
+    needs: set_envs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.github_token }}

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,27 @@
+---
+name: reviewdog
+on: [pull_request]
+jobs:
+  #Python formatting
+  black:
+    name: runner / black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-black@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+  #Python style
+  wemake-python-styleguide:
+    name: runnner / wemake-python-styleguide
+    runs-on: ubuntu-latest
+    steps:
+      - name: wemake-python-styleguide
+        uses: wemake-services/wemake-python-styleguide@0.14.1
+  mypy:
+    name: runner / mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tsuyoshicho/action-mypy@v1
+        with:
+          github_token: ${{ secrets.github_token }}

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -1,0 +1,12 @@
+---
+name: reviewdog
+on: [pull_request]
+jobs:
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}

--- a/.github/workflows/lint-spelling.yml
+++ b/.github/workflows/lint-spelling.yml
@@ -1,0 +1,13 @@
+---
+name: reviewdog
+on: [pull_request]
+jobs:
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          locale: "US"

--- a/.github/workflows/lint-style.yml
+++ b/.github/workflows/lint-style.yml
@@ -1,0 +1,12 @@
+---
+name: reviewdog
+on: [pull_request]
+jobs:
+  stylelint:
+    name: runner / stylelint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-stylelint@v1
+        with:
+          github_token: ${{ secrets.github_token }}

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: reviewdog/action-yamllint@v1
         with:
           github_token: ${{ secrets.github_token }}
-          yamllint_flags: '-c .github/actions/yamllint.yml'
+          yamllint_flags: "-c .github/actions/yamllint.yml"

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,13 @@
+---
+name: reviewdog
+on: [pull_request]
+jobs:
+  yamllint:
+    name: runner / yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-yamllint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          yamllint_flags: '-c .github/actions/yamllint.yml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.pylint.messages_control]
+disable = "C0330, C0326"
+
+[tool.pylint.format]
+max-line-length = "88"
+
+[tool.black]
+line-length = 88


### PR DESCRIPTION
We want to enable automatic code checks
Initially, the tools black and pylint are supported.

Reviewdog outputs these changes as github checks, as well
as suggesting changes on PR review

Configuration for linters is stored in pyproject.toml