### PR TITLE
add exclusions for django migrations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 
 [tool.black]
-line-length = 79
+# Set line length explicitly. https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length
+line-length = 88
 exclude = "/*migrations*/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 
 [tool.black]
-# Set line length explicitly. https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length
+# Set line length explicitly.
+# See https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length for more details
 line-length = 88
 exclude = "/*migrations*/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,4 @@
-[tool.pylint.messages_control]
-disable = "C0330, C0326"
-
-[tool.pylint.format]
-max-line-length = "88"
 
 [tool.black]
-line-length = 88
+line-length = 79
+exclude = "/*migrations*/"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [flake8]
 # line length is intentionally set to 80 here because black uses Bugbear
-# See https://github.com/psf/black/blob/master/docs/the_black_code_style.md#line-length for more details
+# See https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length for more details
 max-line-length = 80
 # Enable bugbear opitionated warnings for line length
 select = C,E,F,W,B,B950

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [flake8]
-#Black Compat
-max-line-length = 79
-extend-ignore = E203, W503
+# line length is intentionally set to 80 here because black uses Bugbear
+# See https://github.com/psf/black/blob/master/docs/the_black_code_style.md#line-length for more details
+max-line-length = 80
+# Enable bugbear opitionated warnings for line length
+select = C,E,F,W,B,B950
+# Ignore E501 for B950 compat
+extend-ignore = E203, E501, W503
 #Django Compat
 exclude = .git,*migrations*

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[flake8]
+#Black Compat
+max-line-length = 79
+extend-ignore = E203, W503
+#Django Compat
+exclude = .git,*migrations*


### PR DESCRIPTION
Black and Flake8 config to be compatible with django projects.
Flake8 currently cannot be configured via pyproject.toml,
but many projects already have a tox.ini file.

Line length could be adjusted higher, up to 119 for code, and 79 for
docs as per:
https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#python-style