### PR TITLE
pretty-print sql logs

### DIFF
--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -297,12 +297,21 @@ LOGGING = {
         'default': {
             'format': '[DJANGO] %(levelname)s %(asctime)s %(module)s %(name)s.%(funcName)s: %(message)s'
         },
+        "sql": {
+            "()": "util.sql_format.SQLFormatter",
+            "format": "[DJANGO-SQL] [%(duration).3f] %(statement)s",
+        },
     },
     'handlers': {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'default',
+        },
+        'console-sql': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'sql',
         },
     },
     'loggers': {
@@ -319,7 +328,7 @@ LOGGING = {
             'level': 'INFO',
         },
         'django.db.backends': {
-            'handlers': ['console'],
+            'handlers': ['console-sql'],
             'level': 'DEBUG' if DEBUG else 'INFO',
             'propagate': False,
         },

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -23,6 +23,8 @@ django-parler~=2.0,<2.2
 bibtexparser<1.2.0
 python3-openid~=3.2.0
 
+mysqlclient~=1.0
+
 # Copied from openstack/requirements@stable/train
 python-glanceclient===2.17.1
 python-keystoneclient===3.21.0

--- a/util/sql_format.py
+++ b/util/sql_format.py
@@ -1,0 +1,35 @@
+import logging
+
+
+class SQLFormatter(logging.Formatter):
+    def format(self, record):
+        # Check if Pygments is available for coloring
+        try:
+            import pygments
+            from pygments.lexers import SqlLexer
+            from pygments.formatters import TerminalTrueColorFormatter
+        except ImportError:
+            pygments = None
+
+        # Check if sqlparse is available for indentation
+        try:
+            import sqlparse
+        except ImportError:
+            sqlparse = None
+
+        # Remove leading and trailing whitespaces
+        sql = record.sql.strip()
+
+        if sqlparse:
+            # Indent the SQL query
+            sql = sqlparse.format(sql, reindent=True)
+
+        if pygments:
+            # Highlight the SQL query
+            sql = pygments.highlight(
+                sql, SqlLexer(), TerminalTrueColorFormatter(style="monokai")
+            )
+
+        # Set the record's statement to the formatted query
+        record.statement = sql
+        return super(SQLFormatter, self).format(record)


### PR DESCRIPTION
This PR fixes sql logging in Django.

We needed to pin the mysql client version.
The Django SQL logs then expose the query explicitly.

Adds a Formatter to optionally pretty-print queries.