### PR TITLE
Use same .env file for docker-compose and makefile.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,36 @@
+###
+# Chameleon Environment Variables
+#
+# This file is used by docker-compose to set and pass
+# environment variables into the container(s) that make
+# up the chameleon portal deployment.
+#
+# Make a copy of this file called '.env' and
+# fill in the appropriate values below.
+###
+
+####
+# Defaults for Makefile and Docker-Compose
+PY_IMG_TAG=3.7.9-stretch
+NODE_VER=lts
+
+PORTAL_PORT = 8888
+DOCKER_REGISTRY = docker.chameleoncloud.org
+DOCKER_IMAGE_LATEST = docker.chameleoncloud.org/portal:latest
+DJANGO_LOG_LEVEL = "DEBUG"
+DJANGO_SQL_LEVEL = "INFO"
+DJANGO_LOG_VERBOSITY = "SHORT" #SHORT/VERBOSE
+DJANGO_SQL_VERBOSITY = "SHORT" #SHORT/VERBOSE
+
+####
+
+# Uncomment and configure these to use a MySQL database
+DB_NAME=chameleon_dev
+DB_HOST=mysql
+DB_PORT=3306
+DB_USER=ccuser
+DB_PASSWORD=ccpass
+
+# Django secret key
+# USE A NEW VALUE IN PRODUCTION
+DJANGO_SECRET_KEY=notreallyasecret

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ db.sqlite3*
 run-script.sh
 .idea
 .chameleon_env
+.env*
 
 media/
 db/

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -23,7 +23,7 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "NOT_A_SECRET")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DJANGO_ENV", "DEBUG") == "DEBUG"
 
-## OpenStack Properties
+# OpenStack Properties
 OPENSTACK_UC_REGION = os.environ.get("OPENSTACK_UC_REGION", "CHI@UC")
 OPENSTACK_TACC_REGION = os.environ.get("OPENSTACK_TACC_REGION", "CHI@TACC")
 OPENSTACK_KVM_REGION = os.environ.get("OPENSTACK_KVM_REGION", "KVM@TACC")
@@ -44,7 +44,7 @@ OPENSTACK_AUTH_REGIONS = {
         "OPENSTACK_KVM_AUTH_URL", "https://kvm.tacc.chameleoncloud.org:5000/v3"
     ),
 }
-## Change to http for local dev only
+# Change to http for local dev only
 SSO_CALLBACK_PROTOCOL = os.environ.get("SSO_CALLBACK_PROTOCOL", "https")
 SSO_CALLBACK_VALID_HOSTS = os.environ.get("SSO_CALLBACK_VALID_HOSTS", [])
 
@@ -249,7 +249,6 @@ STATICFILES_FINDERS = (
 
 LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
 
-
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication"
@@ -275,8 +274,7 @@ DYNAMIC_REST = {
     "ENABLE_BROWSABLE_API": DEBUG,
 }
 
-
-## Keycloak OIDC Authentication
+# Keycloak OIDC Authentication
 OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET")
 OIDC_RP_SIGN_ALGO = os.environ.get("OIDC_RP_SIGN_ALGO")
@@ -291,7 +289,7 @@ OIDC_RENEW_TOKEN_EXPIRY_SECONDS = 60 * 5
 OIDC_EXEMPT_URLS = ["logout"]
 LOGOUT_REDIRECT_URL = os.environ.get("LOGOUT_REDIRECT_URL")
 
-## Keycloak Client
+# Keycloak Client
 KEYCLOAK_SERVER_URL = os.environ.get("KEYCLOAK_SERVER_URL")
 KEYCLOAK_REALM_NAME = os.environ.get("KEYCLOAK_REALM_NAME", "chameleon")
 KEYCLOAK_PORTAL_ADMIN_CLIENT_ID = os.environ.get("KEYCLOAK_PORTAL_ADMIN_CLIENT_ID")
@@ -368,68 +366,26 @@ LOGGING = {
         },
     },
     "loggers": {
-        "default": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "console": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "django": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
+        "default": {"handlers": ["console"], "level": "DEBUG"},
+        "console": {"handlers": ["console"], "level": "DEBUG"},
+        "django": {"handlers": ["console"], "level": "INFO"},
         "django.db.backends": {
             "handlers": ["console-sql"],
             "level": "DEBUG",
             "propagate": False,
         },
-        "pipeline": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
-        "pytas": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
+        "pipeline": {"handlers": ["console"], "level": "INFO"},
+        "pytas": {"handlers": ["console"], "level": "INFO"},
         "chameleon_cms_integrations": {"handlers": ["console"], "level": "INFO"},
-        "openid": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "chameleon": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "auth": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "tas": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "projects": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "sharing_portal": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "allocations": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
-        "chameleon_mailman": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
-        "util": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-        },
+        "openid": {"handlers": ["console"], "level": "INFO"},
+        "chameleon": {"handlers": ["console"], "level": "INFO"},
+        "auth": {"handlers": ["console"], "level": "INFO"},
+        "tas": {"handlers": ["console"], "level": "INFO"},
+        "projects": {"handlers": ["console"], "level": "INFO"},
+        "sharing_portal": {"handlers": ["console"], "level": "INFO"},
+        "allocations": {"handlers": ["console"], "level": "INFO"},
+        "chameleon_mailman": {"handlers": ["console"], "level": "INFO"},
+        "util": {"handlers": ["console"], "level": "INFO"},
     },
 }
 
@@ -444,7 +400,7 @@ CMS_TOOLBAR_URL__EDIT_ON = (
 )
 
 CMS_TEMPLATES = (
-    ## Customize this
+    # Customize this
     ("cms_page.html", "Default Page"),
     ("cms_custom_page.html", "Advanced Page"),
 )
@@ -754,7 +710,7 @@ PARLER_LANGUAGES = {
     },
 }
 
-### overwrite default django params
+# overwrite default django params
 # ref: https://github.com/divio/django-filer/issues/1031
 FILE_UPLOAD_MAX_MEMORY_SIZE = 10000000
 FILE_UPLOAD_PERMISSIONS = 0o644

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -21,6 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "NOT_A_SECRET")
 
 # SECURITY WARNING: don't run with debug turned on in production!
+# https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-DEBUG
 DEBUG = os.environ.get("DJANGO_ENV", "DEBUG") == "DEBUG"
 
 # OpenStack Properties
@@ -319,8 +320,6 @@ OPENID_PROVIDERS = {
 # Logger config
 #
 #####
-
-# DEBUG = True if DJANGO_ENV_DEBUG==DEBUG
 LOG_LEVEL = os.environ.get("DJANGO_LOG_LEVEL", "INFO")
 LOG_VERBOSITY = os.environ.get("DJANGO_LOG_VERBOSITY", "SHORT")
 SQL_LEVEL = os.environ.get("DJANGO_SQL_LEVEL", "INFO")
@@ -560,6 +559,7 @@ TEMPLATES = [
                 "sekizai.context_processors.sekizai",
                 "cms.context_processors.cms_settings",
             ],
+            # https://docs.djangoproject.com/en/1.11/topics/templates/#module-django.template.backends.django
             "debug": os.environ.get("DJANGO_ENV", "DEBUG") == "DEBUG",
         },
     },

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -1,4 +1,6 @@
 """
+Django settings file. This gets most values by loading a .env file.
+
 For more information on this file, see
 https://docs.djangoproject.com/en/1.11/topics/settings/
 
@@ -319,6 +321,15 @@ OPENID_PROVIDERS = {
 # Logger config
 #
 #####
+
+# DEBUG = True if DJANGO_ENV_DEBUG==DEBUG
+LOG_LEVEL = os.environ.get("DJANGO_LOG_LEVEL", "INFO")
+LOG_VERBOSITY = os.environ.get("DJANGO_LOG_VERBOSITY", "SHORT")
+SQL_LEVEL = os.environ.get("DJANGO_SQL_LEVEL", "INFO")
+SQL_VERBOSITY = os.environ.get("DJANGO_SQL_VERBOSITY", "SHORT")
+CONSOLE_WIDTH = os.environ.get("DJANGO_LOG_WIDTH", 100)
+CONSOLE_INDENT = os.environ.get("DJANGO_LOG_INDENT", 2)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -328,26 +339,32 @@ LOGGING = {
         },
     },
     "formatters": {
-        "default": {
+        "default_short": {
+            "format": "[DJANGO] %(levelname)s %(name)s.%(funcName)s: %(message)s"
+        },
+        "default_verbose": {
             "format": "[DJANGO] %(levelname)s %(asctime)s %(module)s %(name)s.%(funcName)s: %(message)s"
         },
-        "sql": {
+        "sql_short": {
+            "format": "[DJANGO-SQL] [%(duration).3f] %(sql)s",
+        },
+        "sql_verbose": {
             "()": "util.sql_format.SQLFormatter",
             "format": "[DJANGO-SQL] [%(duration).3f] %(statement)s",
         },
     },
     "handlers": {
         "console": {
-            "level": "DEBUG",
             "filters": ["require_debug_true"],
+            "level": LOG_LEVEL,
             "class": "logging.StreamHandler",
-            "formatter": "default",
+            "formatter": f"default_{LOG_VERBOSITY.lower()}",
         },
         "console-sql": {
-            "level": "INFO",
             "filters": ["require_debug_true"],
+            "level": SQL_LEVEL,
             "class": "logging.StreamHandler",
-            "formatter": "sql",
+            "formatter": f"sql_{SQL_VERBOSITY.lower()}",
         },
     },
     "loggers": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,18 +5,19 @@ services:
     image: ${DOCKER_IMAGE_LATEST}
     restart: on-failure
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8888"]
+      test: ["CMD", "curl", "-f", "http://localhost:${PORTAL_PORT}"]
       timeout: 10s
-      retries: 10
+      retries: 3
     env_file:
-      - .chameleon_env
+      - .env
     volumes:
       - .:/project
       - ./media:/media
       - static:/static
     ports:
-      - 127.0.0.1:8890:8888
-    command: python3 manage.py runserver 0.0.0.0:8888
+      - 127.0.0.1:8890:${PORTAL_PORT}
+    entrypoint: ["python3", "manage.py"]
+    command: ["runserver", "0.0.0.0:${PORTAL_PORT}"]
     depends_on:
       - mysql
   referenceapi:
@@ -34,10 +35,10 @@ services:
       timeout: 10s
       retries: 10
     environment:
-      MYSQL_ROOT_PASSWORD: ccpass
-      MYSQL_DATABASE: chameleon_dev
-      MYSQL_USER: ccuser
-      MYSQL_PASSWORD: ccpass
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     ports:
@@ -52,9 +53,11 @@ services:
   celery:
     image: ${DOCKER_IMAGE_LATEST}
     restart: on-failure
-    command: celery -A chameleon worker -l INFO --concurrency=1 -B
+    entrypoint: ["celery"]
+    command:
+      ["-A", "chameleon", "worker", "-l", "INFO", "--concurrency=1", "-B"]
     env_file:
-      - .chameleon_env
+      - .env
     volumes:
       - .:/project
     depends_on:

--- a/util/sql_format.py
+++ b/util/sql_format.py
@@ -1,8 +1,14 @@
-import logging
+"""Pretty-Print SQL queries for console output."""
+from logging import Formatter
+
+from django.conf import settings
 
 
-class SQLFormatter(logging.Formatter):
+class SQLFormatter(Formatter):
+    """Color code with pygments, format with sqlparse."""
+
     def format(self, record):
+        """Do the formatting."""
         # Check if Pygments is available for coloring
         try:
             import pygments
@@ -22,7 +28,12 @@ class SQLFormatter(logging.Formatter):
 
         if sqlparse:
             # Indent the SQL query
-            sql = sqlparse.format(sql, reindent=True)
+            sql = sqlparse.format(
+                sql,
+                wrap_after=settings.CONSOLE_WIDTH,
+                indent_width=settings.CONSOLE_INDENT,
+                output_format="python",
+            )
 
         if pygments:
             # Highlight the SQL query


### PR DESCRIPTION
There's a bit of noise in the PR due to the auto-formatter, I can clean that up into two commits if needed.

The purpose of this PR is to:
1. Clean up the logging configuration for easier debugging.
2. Put configuration paramaters that are common to both the makefile, docker-compose file, and running container, into the .chameleon_env file
3. rename .chameleon_env to .env, so that docker-compose will automatically use it without specifying --env-file
4. add a valid .sample.env to the repo, so that local development has fewer manual steps
5. add a target to the makefile to copy .sample.env -> .env if missing