### PR TITLE
Use Github actions to test portal build

### DIFF
--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: whoan/docker-build-with-cache-action@v5
-        with:
-          registry: docker.chameleoncloud.org
-          image_name: portal
-          pull_image_and_stages: false
-          push_image_and_stages: false
+      - name: build container
+        run: make build
+      - name: start env for tests
+        run: make start
+      - name: run migration tests
+        run: make migrations

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -12,33 +12,46 @@ jobs:
       PYTHON_BASEIMG: 3.7.9-stretch
       NODE_VERSION: lts
     steps:
-      - name: checkout source
-        uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
+        
+      - name: Cache Frontend Image layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-client-cache
+          key: ${{ runner.os }}-buildx-client-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-cient-
+            
+      - name: Cache Portal Image layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+            
       - name: Login to docker.chameleoncloud.org
         uses: docker/login-action@v1
         with:
           registry: ${{env.REGISTRY_URL}}
           username: ${{ secrets.REGISTRY_RO_USER }}
           password: ${{ secrets.REGISTRY_RO_PW }}
+          
+      - name: checkout source
+        uses: actions/checkout@v2
+
       - name: Build Frontend Image
         uses: docker/build-push-action@v2
         with:
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache 
+          cache-from: type=local,src=/tmp/.buildx-client-cache
+          cache-to: type=local,dest=/tmp/.buildx-client-cache
           push: false
           load: true
           context: .
           file: ./docker/client/Dockerfile
-          tags: client:latest
+          tags: client
+
       - name: Build Portal Image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -32,17 +32,22 @@ jobs:
       - name: Build Frontend Image
         uses: docker/build-push-action@v2
         with:
-          push: false
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache 
+          push: false
+          load: true
+          context: .
           file: ./docker/client/Dockerfile
           tags: client:latest
       - name: Build Portal Image
         uses: docker/build-push-action@v2
         with:
-          push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          push: false
+          load: true
+          context: .
+          file: ./Dockerfile
           tags: portal:latest
           build-args: |
             PY_IMG_TAG=${{env.PYTHON_BASEIMG}}

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: populate sample environment
+        run: make .env
       - name: build container
         run: make build
       - name: start env for tests

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -27,8 +27,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{env.REGISTRY_URL}}
-          username: ${{ secrets.DOCKER_REGISTRY_RO_USER }}
-          password: ${{ secrets.DOCKER_REGISTRY_RO_PW }}
+          username: ${{ secrets.REGISTRY_RO_USER }}
+          password: ${{ secrets.REGISTRY_RO_PW }}
       - name: Build Portal Image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -29,13 +29,21 @@ jobs:
           registry: ${{env.REGISTRY_URL}}
           username: ${{ secrets.REGISTRY_RO_USER }}
           password: ${{ secrets.REGISTRY_RO_PW }}
+      - name: Build Frontend Image
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          file: ./docker/client/Dockerfile
+          tags: client:latest
       - name: Build Portal Image
         uses: docker/build-push-action@v2
         with:
           push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          tags: user/app:latest
+          tags: portal:latest
           build-args: |
             PY_IMG_TAG=${{env.PYTHON_BASEIMG}}
             NODE_VER=${{env.NODE_VERSION}}

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -7,13 +7,35 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      REGISTRY_URL: docker.chameleoncloud.org
+      PYTHON_BASEIMG: 3.7.9-stretch
+      NODE_VERSION: lts
     steps:
-      - uses: actions/checkout@v2
-      - name: populate sample environment
-        run: make .env
-      - name: build container
-        run: make build
-      - name: start env for tests
-        run: make start
-      - name: run migration tests
-        run: make migrations
+      - name: checkout source
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to docker.chameleoncloud.org
+        uses: docker/login-action@v1
+        with:
+          registry: ${{env.REGISTRY_URL}}
+          username: ${{ secrets.DOCKER_REGISTRY_RO_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_RO_PW }}
+      - name: Build Portal Image
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: user/app:latest
+          build-args: |
+            PY_IMG_TAG=${{env.PYTHON_BASEIMG}}
+            NODE_VER=${{env.NODE_VERSION}}

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -46,3 +46,9 @@ jobs:
           build-args: |
             PY_IMG_TAG=${{env.PYTHON_BASEIMG}}
             NODE_VER=${{env.NODE_VERSION}}
+      - name: setup env for tests
+        run: make .env
+      - name: start compose for tests
+        run: make start
+      - name: run migrations check
+        run: make migrations

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -1,9 +1,9 @@
 name: build-portal
 on:
   push:
-    branches: [$default-branch]
+    branches: [master]
   pull_request:
-    branches: [$default-branch]
+    branches: [master]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -14,15 +14,7 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        
-      - name: Cache Frontend Image layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-client-cache
-          key: ${{ runner.os }}-buildx-client-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-cient-
-            
+                    
       - name: Cache Portal Image layers
         uses: actions/cache@v2
         with:
@@ -41,22 +33,11 @@ jobs:
       - name: checkout source
         uses: actions/checkout@v2
 
-      - name: Build Frontend Image
-        uses: docker/build-push-action@v2
-        with:
-          cache-from: type=local,src=/tmp/.buildx-client-cache
-          cache-to: type=local,dest=/tmp/.buildx-client-cache
-          push: false
-          load: true
-          context: .
-          file: ./docker/client/Dockerfile
-          tags: client
-
       - name: Build Portal Image
         uses: docker/build-push-action@v2
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
           push: false
           load: true
           context: .

--- a/.github/workflows/build-portal.yml
+++ b/.github/workflows/build-portal.yml
@@ -1,0 +1,17 @@
+name: build-portal
+on:
+  push:
+    branches: [$default-branch]
+  pull_request:
+    branches: [$default-branch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: whoan/docker-build-with-cache-action@v5
+        with:
+          registry: docker.chameleoncloud.org
+          image_name: portal
+          pull_image_and_stages: false
+          push_image_and_stages: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,18 @@ WORKDIR /project
 COPY package.json package.json
 COPY yarn.lock yarn.lock
 RUN yarn install
-COPY --from=node-deps node_modules /project/node_modules
-
 # Build static JS assets
 COPY . /project
 RUN yarn build --production
 
 # Build Django Application
 ARG PY_IMG_TAG=3.7.9-stretch
-FROM python:${PY_IMG_TAG}
+FROM python:${PY_IMG_TAG} as portal
 
 # Set shell to use for run commands
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install repos for node6.x. 
-# WARNING: EOL on 2019-04-30
-# https://github.com/nodejs/Release#end-of-life-releases
+# Install repos for node
 ARG NODE_VER=lts
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VER}.x | bash -
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-# Build Frontend Client
+# Docker Build Args
+# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG NODE_VER=lts
-FROM node:${NODE_VER} as node-client
+ARG PY_IMG_TAG=3.7.9-stretch
 
+# Build Frontend Client
+FROM node:${NODE_VER} as node-client
 # Avoid rebuilding node deps unnecessarily
 WORKDIR /project
 COPY package.json package.json
@@ -12,14 +15,13 @@ COPY . /project
 RUN yarn build --production
 
 # Build Django Application
-ARG PY_IMG_TAG=3.7.9-stretch
 FROM python:${PY_IMG_TAG} as portal
 
 # Set shell to use for run commands
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install repos for node
-ARG NODE_VER=lts
+ARG NODE_VER
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VER}.x | bash -
 
 # Install apt packages


### PR DESCRIPTION
This was a naive look at building the portal container with GH actions.

The v2 docker actions now support caching using buildkit, allowing us to use a single multi-stage build
without speed penalties.

TODO:
Figure out how to import a "sanitized" db, and run migration tests.

TODO: Publish containers somewhere.