### PR TITLE
Add notion of Chameleon-supported artifacts

### DIFF
--- a/sharing_portal/forms.py
+++ b/sharing_portal/forms.py
@@ -7,13 +7,19 @@ from projects.models import Project
 from .models import Artifact, ArtifactVersion, Author, Label
 
 import logging
+
 LOG = logging.getLogger(__name__)
 
 
 class ArtifactForm(forms.ModelForm):
     class Meta:
         model = Artifact
-        fields = ("title", "short_description", "description", "labels",)
+        fields = (
+            "title",
+            "short_description",
+            "description",
+            "labels",
+        )
 
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop("request")
@@ -24,16 +30,17 @@ class ArtifactForm(forms.ModelForm):
         if self.request.user.is_staff:
             available_labels = Label.objects.all()
         else:
-            available_labels = (
-                Label.objects.filter(~Q(label=Label.CHAMELEON_SUPPORTED)))
+            available_labels = Label.objects.filter(~Q(label=Label.CHAMELEON_SUPPORTED))
 
         self.fields["labels"] = forms.ModelMultipleChoiceField(available_labels)
 
     def clean_labels(self):
         labels = self.cleaned_data["labels"]
         # Ensure only staff members can save w/ the "chameleon" label.
-        if (any(l.label == Label.CHAMELEON_SUPPORTED for l in labels) and
-            not self.request.user.is_staff):
+        if (
+            any(l.label == Label.CHAMELEON_SUPPORTED for l in labels)
+            and not self.request.user.is_staff
+        ):
             raise ValidationError("Invalid label")
         return labels
 

--- a/sharing_portal/forms.py
+++ b/sharing_portal/forms.py
@@ -1,14 +1,41 @@
+from django.db.models import Q
+from django.core.exceptions import ValidationError
 from django import forms
 
 from projects.models import Project
 
 from .models import Artifact, ArtifactVersion, Author, Label
 
+import logging
+LOG = logging.getLogger(__name__)
+
 
 class ArtifactForm(forms.ModelForm):
     class Meta:
         model = Artifact
-        fields = ('title', 'short_description', 'description', 'labels',)
+        fields = ("title", "short_description", "description", "labels",)
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super().__init__(*args, **kwargs)
+
+        # Only allow staff members to use the special "Chameleon-supported"
+        # label on the artifact.
+        if self.request.user.is_staff:
+            available_labels = Label.objects.all()
+        else:
+            available_labels = (
+                Label.objects.filter(~Q(label=Label.CHAMELEON_SUPPORTED)))
+
+        self.fields["labels"] = forms.ModelMultipleChoiceField(available_labels)
+
+    def clean_labels(self):
+        labels = self.cleaned_data["labels"]
+        # Ensure only staff members can save w/ the "chameleon" label.
+        if (any(l.label == Label.CHAMELEON_SUPPORTED for l in labels) and
+            not self.request.user.is_staff):
+            raise ValidationError("Invalid label")
+        return labels
 
 
 class ArtifactVersionForm(forms.ModelForm):

--- a/sharing_portal/models.py
+++ b/sharing_portal/models.py
@@ -72,7 +72,7 @@ class Label(models.Model):
     label = LabelField(max_length=50)
 
     class Meta:
-        ordering = ('label',)
+        ordering = ("label",)
 
     CHAMELEON_SUPPORTED = "chameleon"
 
@@ -152,8 +152,7 @@ class Artifact(models.Model):
 
     @property
     def is_chameleon_supported(self) -> "bool":
-        """Indicate whether this artifact is maintained by Chameleon.
-        """
+        """Indicate whether this artifact is maintained by Chameleon."""
         # We don't use a .filter here because .all is already used everywhere,
         # and if we use .all here, it's already cached.
         return any(l.label == Label.CHAMELEON_SUPPORTED for l in self.labels.all())
@@ -162,10 +161,7 @@ class Artifact(models.Model):
     def display_labels(self) -> "list[Label]":
         # We don't use a .filter here because .all is already used everywhere,
         # and if we use .all here, it's already cached.
-        return [
-            l for l in self.labels.all()
-            if l.label != Label.CHAMELEON_SUPPORTED
-        ]
+        return [l for l in self.labels.all() if l.label != Label.CHAMELEON_SUPPORTED]
 
 
 class ArtifactVersion(models.Model):

--- a/sharing_portal/static/sharing_portal/artifacts.css
+++ b/sharing_portal/static/sharing_portal/artifacts.css
@@ -108,8 +108,12 @@
     font-size: 1.4rem;
     padding: 0.2rem 1rem;
     margin-right: 0.5rem;
+    vertical-align: middle;
 } .artifactStats__labels > a:last-child {
     margin-right: 0;
+} .artifactStats__labels > .artifactStats__chameleonSupported {
+    background: none;
+    padding: 0;
 }
 
 .sidebarHeading {}

--- a/sharing_portal/templates/sharing_portal/includes/stats.html
+++ b/sharing_portal/templates/sharing_portal/includes/stats.html
@@ -1,3 +1,5 @@
+{% load staticfiles %}
+
 <div class="artifactStats">
   <div class="artifactStats__meta">
     {% if version and version.launch_count %}
@@ -9,8 +11,13 @@
     <span class="artifactStats__updated">{{ artifact.updated_at }}</span>
   </div>
   <div class="artifactStats__labels">
-    {% for label in artifact.labels.all %}
-    <a href="{% url 'sharing_portal:index_all' %}?filter={{ label.label|urlencode }}">{{ label.label }}</a>
+    {% for label in artifact.display_labels %}
+    <a href="{% url 'sharing_portal:index_all' %}?filter=tag:{{ label.label|urlencode }}">{{ label.label }}</a>
     {% endfor %}
+    {% if artifact.is_chameleon_supported %}
+    <a href="{% url 'sharing_portal:index_all' %}?filter=tag:chameleon" class="artifactStats__chameleonSupported" title="This artifact is supported by the Chameleon team">
+      <img src="{% static 'images/logo-small.png' %}" alt="Small Chameleon logo">
+    </a>
+    {% endif %}
   </div>
 </div>

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -178,11 +178,11 @@ def _fetch_artifacts(filters):
 @check_edit_permission
 @login_required
 def edit_artifact(request, artifact):
-    if request.method == 'POST':
+    if request.method == "POST":
         form = ArtifactForm(request.POST, instance=artifact, request=request)
 
-        if 'delete_version' in request.POST:
-            version_id = request.POST.get('delete_version')
+        if "delete_version" in request.POST:
+            version_id = request.POST.get("delete_version")
             try:
                 version = artifact.versions.get(pk=version_id)
                 if not version.doi:
@@ -205,10 +205,11 @@ def edit_artifact(request, artifact):
         else:
             messages.add_message(request, messages.SUCCESS, 'Successfully saved artifact.')
         return HttpResponseRedirect(
-            reverse('sharing_portal:detail', args=[artifact.pk]))
+            reverse("sharing_portal:detail", args=[artifact.pk])
+        )
 
     form = ArtifactForm(instance=artifact, request=request)
-    template = loader.get_template('sharing_portal/edit.html')
+    template = loader.get_template("sharing_portal/edit.html")
     context = {
         'artifact_form': form,
         'artifact': artifact,
@@ -354,9 +355,9 @@ def embed_cancel(request):
 
 
 def _embed_form(request, artifact=None, context={}):
-    new_version = (not artifact) or ('new_version' in request.GET)
+    new_version = (not artifact) or ("new_version" in request.GET)
 
-    if request.method == 'POST':
+    if request.method == "POST":
         form = ArtifactForm(request.POST, instance=artifact, request=request)
         authors_formset = AuthorFormset(request.POST)
         if (not artifact) or new_version:

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -179,7 +179,7 @@ def _fetch_artifacts(filters):
 @login_required
 def edit_artifact(request, artifact):
     if request.method == 'POST':
-        form = ArtifactForm(request.POST, instance=artifact)
+        form = ArtifactForm(request.POST, instance=artifact, request=request)
 
         if 'delete_version' in request.POST:
             version_id = request.POST.get('delete_version')
@@ -207,7 +207,7 @@ def edit_artifact(request, artifact):
         return HttpResponseRedirect(
             reverse('sharing_portal:detail', args=[artifact.pk]))
 
-    form = ArtifactForm(instance=artifact)
+    form = ArtifactForm(instance=artifact, request=request)
     template = loader.get_template('sharing_portal/edit.html')
     context = {
         'artifact_form': form,
@@ -357,7 +357,7 @@ def _embed_form(request, artifact=None, context={}):
     new_version = (not artifact) or ('new_version' in request.GET)
 
     if request.method == 'POST':
-        form = ArtifactForm(request.POST, instance=artifact)
+        form = ArtifactForm(request.POST, instance=artifact, request=request)
         authors_formset = AuthorFormset(request.POST)
         if (not artifact) or new_version:
             version_form = ArtifactVersionForm(request.POST)
@@ -374,7 +374,7 @@ def _embed_form(request, artifact=None, context={}):
             for err in errors:
                 messages.add_message(request, messages.ERROR, err)
     else:
-        form = ArtifactForm(instance=artifact)
+        form = ArtifactForm(instance=artifact, request=request)
         if artifact:
             queryset = artifact.authors.all()
             initial = None


### PR DESCRIPTION
An artifact is Chameleon supported if the Chameleon team is reponsible
for maintenance. This is indicated via a special label named "chameleon".
If that label is set, an additional icon is included in the tag labels
UI section. This label can only be set by Portal staff members and
normal users do not even see it.