### PR TITLE
Fixup RT ticket views

### DIFF
--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -328,6 +328,10 @@ SQL_VERBOSITY = os.environ.get("DJANGO_SQL_VERBOSITY", "SHORT")
 CONSOLE_WIDTH = os.environ.get("DJANGO_LOG_WIDTH", 100)
 CONSOLE_INDENT = os.environ.get("DJANGO_LOG_INDENT", 2)
 
+import logging
+# Ensure Python `warnings` are ingested by logging infra
+logging.captureWarnings(True)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -369,6 +373,11 @@ LOGGING = {
         "default": {"handlers": ["console"], "level": "DEBUG"},
         "console": {"handlers": ["console"], "level": "DEBUG"},
         "django": {"handlers": ["console"], "level": "INFO"},
+        "py.warnings": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": True,
+        },
         "django.db.backends": {
             "handlers": ["console-sql"],
             "level": "DEBUG",

--- a/djangoRT/admin.py
+++ b/djangoRT/admin.py
@@ -2,7 +2,9 @@ from django.contrib import admin
 
 from .models import TicketCategories
 
+
 class TicketCategoriesAdmin(admin.ModelAdmin):
     list_display = ("category_display_name", "category_field_name")
+
 
 admin.site.register(TicketCategories, TicketCategoriesAdmin)

--- a/djangoRT/forms.py
+++ b/djangoRT/forms.py
@@ -5,6 +5,7 @@ from captcha.fields import CaptchaField
 from .models import TicketCategories
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 # This was pulled from : https://docs.djangoproject.com/en/1.7/ref/forms/validation/
@@ -15,7 +16,7 @@ class MultiEmailField(forms.Field):
         # Return an empty list if no input was given.
         if not value:
             return []
-        return value.split(',')
+        return value.split(",")
 
     def validate(self, value):
         """ Check if value consists only of valid emails. """
@@ -28,30 +29,44 @@ class MultiEmailField(forms.Field):
 
 
 def get_ticket_categories():
-    return (('', 'Choose one'),) + tuple(TicketCategories.objects.order_by('category_display_name').values_list('category_field_name', 'category_display_name'))
+    return (("", "Choose one"),) + tuple(
+        TicketCategories.objects.order_by("category_display_name").values_list(
+            "category_field_name", "category_display_name"
+        )
+    )
 
 
 class BaseTicketForm(forms.Form):
-    """Base form class for Tickets.
-    """
+    """Base form class for Tickets."""
 
     help_text = (
         "In order to help us address your issue in a timely manner, please "
         "be sure to provide your project name and the details of your problem, "
         "including your username and the UUID of the instance or lease in "
-        "question if applicable.")
+        "question if applicable."
+    )
 
-    first_name = forms.CharField(widget=forms.TextInput(), label='First name', max_length=100, required=True)
-    last_name = forms.CharField(widget=forms.TextInput(), label='Last name', max_length=100, required=True)
-    email = forms.EmailField(widget=forms.EmailInput(), label='Email', required=True)
-    subject = forms.CharField(widget=forms.TextInput(), label='Subject', max_length=100, required=True)
+    first_name = forms.CharField(
+        widget=forms.TextInput(), label="First name", max_length=100, required=True
+    )
+    last_name = forms.CharField(
+        widget=forms.TextInput(), label="Last name", max_length=100, required=True
+    )
+    email = forms.EmailField(widget=forms.EmailInput(), label="Email", required=True)
+    subject = forms.CharField(
+        widget=forms.TextInput(), label="Subject", max_length=100, required=True
+    )
     category = forms.ChoiceField(required=True)
-    problem_description = forms.CharField(widget=forms.Textarea(attrs={'placeholder': help_text}), label='Problem description', required=True)
+    problem_description = forms.CharField(
+        widget=forms.Textarea(attrs={"placeholder": help_text}),
+        label="Problem description",
+        required=True,
+    )
     attachment = forms.FileField(required=False)
 
     def __init__(self, *args, **kwargs):
         super(BaseTicketForm, self).__init__(*args, **kwargs)
-        self.fields['category'].choices = get_ticket_categories()
+        self.fields["category"].choices = get_ticket_categories()
 
 
 class TicketForm(BaseTicketForm):
@@ -60,11 +75,16 @@ class TicketForm(BaseTicketForm):
     Additional "CC" field. This field is not
     provided to anonymous users because it could be used for spam.
     """
+
     cc = MultiEmailField(
-        widget=forms.TextInput(), label='CC', required=False,
+        widget=forms.TextInput(),
+        label="CC",
+        required=False,
         help_text=(
             "Copy other people on this ticket. Multiple emails should be "
-            "comma-separated"))
+            "comma-separated"
+        ),
+    )
 
 
 class TicketGuestForm(BaseTicketForm):
@@ -72,17 +92,20 @@ class TicketGuestForm(BaseTicketForm):
 
     Adds a CAPTCHA to reduce spam submissions.
     """
+
     captcha = CaptchaField()
 
 
 class ReplyForm(forms.Form):
-    """Ticket Reply form.
-    """
+    """Ticket Reply form."""
+
     reply = forms.CharField(required=True, widget=forms.Textarea(), label="Enter Reply")
     attachment = forms.FileField(required=False)
 
 
 class CloseForm(forms.Form):
-    """Ticket Close form.
-    """
-    reply = forms.CharField(required=True, widget=forms.Textarea(), label="Enter Close Comment")
+    """Ticket Close form."""
+
+    reply = forms.CharField(
+        required=True, widget=forms.Textarea(), label="Enter Close Comment"
+    )

--- a/djangoRT/forms.py
+++ b/djangoRT/forms.py
@@ -1,9 +1,10 @@
 from django import forms
 from django.core.validators import validate_email
 from captcha.fields import CaptchaField
-from .models import TicketCategories
-import logging
 
+from .models import TicketCategories
+
+import logging
 logger = logging.getLogger(__name__)
 
 # This was pulled from : https://docs.djangoproject.com/en/1.7/ref/forms/validation/
@@ -25,25 +26,20 @@ class MultiEmailField(forms.Field):
         for email in value:
             validate_email(email.strip())
 
-# I'm a model now just like an adult
-#TICKET_CATEGORIES = (
-#    ('','Choose one'),
-#    ('ACCTS_PRJ_ALLOC', 'Accounts, Projects, and Allocations'),
-#    ('BARE_METAL','Bare Metal'),
-#    ('OPENSTACK_KVM_CLOUD','OpenStack KVM Cloud'),
-#    ('OTHER','Other'),
-#)
 
 def get_ticket_categories():
     return (('', 'Choose one'),) + tuple(TicketCategories.objects.order_by('category_display_name').values_list('category_field_name', 'category_display_name'))
 
 
 class BaseTicketForm(forms.Form):
-    """
-    Base form class for Tickets.
+    """Base form class for Tickets.
     """
 
-    help_text = 'In order to help us address your issue in a timely manner, please be sure to provide your project name and the details of your problem, including your username and the UUID of the instance or lease in question if applicable.'
+    help_text = (
+        "In order to help us address your issue in a timely manner, please "
+        "be sure to provide your project name and the details of your problem, "
+        "including your username and the UUID of the instance or lease in "
+        "question if applicable.")
 
     first_name = forms.CharField(widget=forms.TextInput(), label='First name', max_length=100, required=True)
     last_name = forms.CharField(widget=forms.TextInput(), label='Last name', max_length=100, required=True)
@@ -59,27 +55,34 @@ class BaseTicketForm(forms.Form):
 
 
 class TicketForm(BaseTicketForm):
-    """
-    Authenticated users ticket form. Additional "CC" field. This field is not
+    """Authenticated users ticket form.
+
+    Additional "CC" field. This field is not
     provided to anonymous users because it could be used for spam.
     """
-    cc = MultiEmailField(widget=forms.TextInput(), label='CC', required=False, help_text='Copy other people on this ticket. Multiple emails should be comma-separated')
+    cc = MultiEmailField(
+        widget=forms.TextInput(), label='CC', required=False,
+        help_text=(
+            "Copy other people on this ticket. Multiple emails should be "
+            "comma-separated"))
+
 
 class TicketGuestForm(BaseTicketForm):
-    """
-    Anonymous users ticket form. Adds a CAPTCHA to reduce spam submissions.
+    """Anonymous users ticket form.
+
+    Adds a CAPTCHA to reduce spam submissions.
     """
     captcha = CaptchaField()
 
+
 class ReplyForm(forms.Form):
-    """
-    Ticket Reply form.
+    """Ticket Reply form.
     """
     reply = forms.CharField(required=True, widget=forms.Textarea(), label="Enter Reply")
     attachment = forms.FileField(required=False)
 
+
 class CloseForm(forms.Form):
-    """
-    Ticket Close form.
+    """Ticket Close form.
     """
     reply = forms.CharField(required=True, widget=forms.Textarea(), label="Enter Close Comment")

--- a/djangoRT/models.py
+++ b/djangoRT/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+
 class TicketCategories(models.Model):
     category_display_name = models.CharField(max_length=200, default="")
     category_field_name = models.CharField(max_length=200, default="")

--- a/djangoRT/rtModels.py
+++ b/djangoRT/rtModels.py
@@ -1,6 +1,6 @@
 class Ticket:
-	def __init__(self, subject = "", problem_description = "", requestor = "", cc=""):
-		self.subject = subject
-		self.problem_description = problem_description
-		self.requestor = requestor
-		self.cc = cc
+    def __init__(self, subject="", problem_description="", requestor="", cc=""):
+        self.subject = subject
+        self.problem_description = problem_description
+        self.requestor = requestor
+        self.cc = cc

--- a/djangoRT/rtUtil.py
+++ b/djangoRT/rtUtil.py
@@ -11,12 +11,12 @@ class DjangoRt:
     RESPONSE_REQUIRED = 'response required'
 
     def __init__(self):
-        self.rtHost = settings.DJANGO_RT['RT_HOST']
-        self.rtUn = settings.DJANGO_RT['RT_UN']
-        self.rtPw = settings.DJANGO_RT['RT_PW']
-        self.rtQueue = settings.DJANGO_RT['RT_QUEUE']
+        host = settings.DJANGO_RT['RT_HOST']
+        username = settings.DJANGO_RT['RT_UN']
+        password = settings.DJANGO_RT['RT_PW']
+        self.queue = settings.DJANGO_RT['RT_QUEUE']
 
-        self.tracker = rt.Rt(self.rtHost, self.rtUn, self.rtPw)
+        self.tracker = rt.Rt(host, username, password)
         self.tracker.login()
 
     def getUserTickets(self, userEmail, show_resolved=False):
@@ -54,7 +54,7 @@ class DjangoRt:
 
     # Returns the ticket id of the created ticket
     def createTicket(self, ticket):
-        return self.tracker.create_ticket(Queue=self.rtQueue,
+        return self.tracker.create_ticket(Queue=self.queue,
                                           Subject=ticket.subject,
                                           Text=ticket.problem_description.replace('\n', '\n '),
                                           Requestors=ticket.requestor,

--- a/djangoRT/rtUtil.py
+++ b/djangoRT/rtUtil.py
@@ -4,17 +4,17 @@ from datetime import datetime
 
 
 class DjangoRt:
-    CLOSED = 'closed'
-    RESOLVED = 'resolved'
-    OPEN = 'open'
-    NEW = 'new'
-    RESPONSE_REQUIRED = 'response required'
+    CLOSED = "closed"
+    RESOLVED = "resolved"
+    OPEN = "open"
+    NEW = "new"
+    RESPONSE_REQUIRED = "response required"
 
     def __init__(self):
-        host = settings.DJANGO_RT['RT_HOST']
-        username = settings.DJANGO_RT['RT_UN']
-        password = settings.DJANGO_RT['RT_PW']
-        self.queue = settings.DJANGO_RT['RT_QUEUE']
+        host = settings.DJANGO_RT["RT_HOST"]
+        username = settings.DJANGO_RT["RT_UN"]
+        password = settings.DJANGO_RT["RT_PW"]
+        self.queue = settings.DJANGO_RT["RT_QUEUE"]
 
         self.tracker = rt.Rt(host, username, password)
         self.tracker.login()
@@ -23,24 +23,26 @@ class DjangoRt:
         if show_resolved:
             query = 'Requestor="%s"' % userEmail
         else:
-            query = 'Requestor="%s" AND Status!="resolved" AND Status!="closed"' % userEmail
+            query = (
+                'Requestor="%s" AND Status!="resolved" AND Status!="closed"' % userEmail
+            )
 
         ticket_list = self.tracker.search(
-            Queue=rt.ALL_QUEUES,
-            raw_query=query,
-            order='-LastUpdated'
+            Queue=rt.ALL_QUEUES, raw_query=query, order="-LastUpdated"
         )
 
         for ticket in ticket_list:
-            ticket['id'] = ticket['id'].replace('ticket/', '')
-            ticket['LastUpdated'] = datetime.strptime(ticket['LastUpdated'], '%a %b %d %X %Y')
+            ticket["id"] = ticket["id"].replace("ticket/", "")
+            ticket["LastUpdated"] = datetime.strptime(
+                ticket["LastUpdated"], "%a %b %d %X %Y"
+            )
 
         return ticket_list
 
     def getTicket(self, ticket_id):
         ticket = self.tracker.get_ticket(ticket_id)
 
-        ticket['id'] = ticket['id'].replace('ticket/', '')
+        ticket["id"] = ticket["id"].replace("ticket/", "")
 
         return ticket
 
@@ -48,28 +50,32 @@ class DjangoRt:
         ticketHistory = self.tracker.get_history(ticket_id)
 
         for ticket in ticketHistory:
-            ticket['Created'] = datetime.strptime(ticket['Created'], '%Y-%m-%d %X')
+            ticket["Created"] = datetime.strptime(ticket["Created"], "%Y-%m-%d %X")
 
         return ticketHistory
 
     # Returns the ticket id of the created ticket
     def createTicket(self, ticket):
-        return self.tracker.create_ticket(Queue=self.queue,
-                                          Subject=ticket.subject,
-                                          Text=ticket.problem_description.replace('\n', '\n '),
-                                          Requestors=ticket.requestor,
-                                          Cc=",".join(ticket.cc))
+        return self.tracker.create_ticket(
+            Queue=self.queue,
+            Subject=ticket.subject,
+            Text=ticket.problem_description.replace("\n", "\n "),
+            Requestors=ticket.requestor,
+            Cc=",".join(ticket.cc),
+        )
 
-    def replyToTicket(self, ticket_id, text='', files=[]):
+    def replyToTicket(self, ticket_id, text="", files=[]):
         return self.tracker.reply(ticket_id, text=text, files=files)
 
-    def commentOnTicket(self, ticket_id, text=''):
+    def commentOnTicket(self, ticket_id, text=""):
         return self.tracker.comment(ticket_id, text=text)
 
     def getAttachment(self, ticketId, attachmentId):
-        attachment_name = self.tracker.get_attachment(ticketId, attachmentId).get("Filename")
-        if attachment_name == '':
-            attachment_name = 'untitled'
+        attachment_name = self.tracker.get_attachment(ticketId, attachmentId).get(
+            "Filename"
+        )
+        if attachment_name == "":
+            attachment_name = "untitled"
         return attachment_name, self.tracker.get_attachment(ticketId, attachmentId)
 
     # Checks if the current user is a requestor or CC on the ticket
@@ -78,7 +84,7 @@ class DjangoRt:
     def hasAccess(self, ticket_id, user=None):
         if user and ticket_id:
             ticket = self.tracker.get_ticket(ticket_id)
-            if user in ticket.get('Requestors', '') or user in ticket.get('Cc', ''):
+            if user in ticket.get("Requestors", "") or user in ticket.get("Cc", ""):
                 return True
 
         return False

--- a/djangoRT/templates/djangoRT/attachment.html
+++ b/djangoRT/templates/djangoRT/attachment.html
@@ -5,5 +5,5 @@
 {% block content %}
     <h2>Attachment : {{ title }} </h2>
     <pre>{{ attachment }}</pre>
-    <a href="{% url 'djangoRT:ticketdetail' ticketId %}"><i class="fa fa-reply"></i> Back to ticket</a>
+    <a href="{% url 'djangoRT:ticketdetail' ticket_id %}"><i class="fa fa-reply"></i> Back to ticket</a>
 {% endblock %}

--- a/djangoRT/urls.py
+++ b/djangoRT/urls.py
@@ -3,10 +3,10 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.mytickets, name='mytickets'),
-    url(r'^ticket/(?P<ticketId>\d+)/$', views.ticketdetail, name='ticketdetail'),
+    url(r'^ticket/(?P<ticket_id>\d+)/$', views.ticketdetail, name='ticketdetail'),
     url(r'^ticket/new/$', views.ticketcreate, name='ticketcreate'),
-    url(r'^ticket/reply/(?P<ticketId>\d+)/$', views.ticketreply, name='ticketreply'),
+    url(r'^ticket/reply/(?P<ticket_id>\d+)/$', views.ticketreply, name='ticketreply'),
     url(r'^ticket/new/guest/$', views.ticketcreateguest, name='ticketcreateguest'),
-    url(r'^ticket/close/(?P<ticketId>\d+)/$', views.ticketclose, name='ticketclose'),
-    url(r'^ticket/attachment/(?P<ticketId>\d+)/(?P<attachmentId>\d+)/$', views.ticketattachment, name='ticketattachment'),
+    url(r'^ticket/close/(?P<ticket_id>\d+)/$', views.ticketclose, name='ticketclose'),
+    url(r'^ticket/attachment/(?P<ticket_id>\d+)/(?P<attachment_id>\d+)/$', views.ticketattachment, name='ticketattachment'),
 ]

--- a/djangoRT/urls.py
+++ b/djangoRT/urls.py
@@ -2,11 +2,15 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.mytickets, name='mytickets'),
-    url(r'^ticket/(?P<ticket_id>\d+)/$', views.ticketdetail, name='ticketdetail'),
-    url(r'^ticket/new/$', views.ticketcreate, name='ticketcreate'),
-    url(r'^ticket/reply/(?P<ticket_id>\d+)/$', views.ticketreply, name='ticketreply'),
-    url(r'^ticket/new/guest/$', views.ticketcreateguest, name='ticketcreateguest'),
-    url(r'^ticket/close/(?P<ticket_id>\d+)/$', views.ticketclose, name='ticketclose'),
-    url(r'^ticket/attachment/(?P<ticket_id>\d+)/(?P<attachment_id>\d+)/$', views.ticketattachment, name='ticketattachment'),
+    url(r"^$", views.mytickets, name="mytickets"),
+    url(r"^ticket/(?P<ticket_id>\d+)/$", views.ticketdetail, name="ticketdetail"),
+    url(r"^ticket/new/$", views.ticketcreate, name="ticketcreate"),
+    url(r"^ticket/reply/(?P<ticket_id>\d+)/$", views.ticketreply, name="ticketreply"),
+    url(r"^ticket/new/guest/$", views.ticketcreateguest, name="ticketcreateguest"),
+    url(r"^ticket/close/(?P<ticket_id>\d+)/$", views.ticketclose, name="ticketclose"),
+    url(
+        r"^ticket/attachment/(?P<ticket_id>\d+)/(?P<attachment_id>\d+)/$",
+        views.ticketattachment,
+        name="ticketattachment",
+    ),
 ]

--- a/djangoRT/views.py
+++ b/djangoRT/views.py
@@ -6,199 +6,235 @@ from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 import logging
 import mimetypes
-from .models import TicketCategories
-from wsgiref.util import FileWrapper
 
-from keystoneclient import client as ks_client
-from keystoneauth1.identity import v3
-from keystoneauth1 import adapter, session
-import json
 from novaclient import client as nova_client
 from blazarclient import client as blazar_client
 from glanceclient import Client as glance_client
-from django.conf import settings
-from datetime import datetime
 from dateutil import parser
-import sys
-from django.template.loader import render_to_string
-from chameleon.keystone_auth import admin_ks_client, get_user, get_token, project_scoped_session
+from chameleon.keystone_auth import admin_ks_client, get_user, project_scoped_session
 
 
 logger = logging.getLogger('default')
 
+
 @login_required
 def mytickets(request):
     rt = rtUtil.DjangoRt()
-    show_resolved = 'show_resolved' in request.GET
+    show_resolved = "show_resolved" in request.GET
     tickets = rt.getUserTickets(request.user.email, show_resolved=show_resolved)
-    return render(request, 'djangoRT/ticketList.html', { 'tickets': tickets, 'show_resolved': show_resolved })
+    return render(request, "djangoRT/ticketList.html", {
+        "tickets": tickets,
+        "show_resolved": show_resolved,
+    })
+
 
 @login_required
-def ticketdetail(request, ticketId):
+def ticketdetail(request, ticket_id):
     rt = rtUtil.DjangoRt()
-    ticket = rt.getTicket(ticketId)
-    ticket_history = rt.getTicketHistory(ticketId)
+    ticket = rt.getTicket(ticket_id)
+    ticket_history = rt.getTicketHistory(ticket_id)
 
     # remove bogus "untitled" attachments
     for history in ticket_history:
-        history['Attachments'] = [a for a in history['Attachments'] if not a[1].startswith('untitled (')]
+        history['Attachments'] = [
+            a for a in history['Attachments']
+            if not a[1].startswith('untitled (')
+        ]
 
-    return render(request, 'djangoRT/ticketDetail.html',\
-        { 'ticket' : ticket, 'ticket_history' : ticket_history, 'ticket_id' : ticketId, 'hasAccess' : rt.hasAccess(ticketId, request.user.email) })
+    return render(request, "djangoRT/ticketDetail.html", {
+        "ticket": ticket,
+        "ticket_history": ticket_history,
+        "ticket_id": ticket_id,
+        "hasAccess": rt.hasAccess(ticket_id, request.user.email)
+    })
+
+
+def _handle_ticket_form(request, form):
+    """Generic ticket handling helper function.
+
+    If the form is invalid: render an error to the user.
+    If the ticket cannot be created: render an error to the user.
+    If the ticket could be created but the attachment could not be attached:
+        just log an error.
+
+    Args:
+        request (Request): The parent request.
+        form (Form): The TicketForm to process. It is assumed this already
+            has the POST/FILES data attached.
+
+    Returns:
+        The ID of the ticket created, if successful. Returns None on error.
+    """
+    if not form.is_valid():
+        messages.error(request,
+            "The form is invalid, ensure all required fields are provided.")
+        return None
+
+    rt = rtUtil.DjangoRt()
+
+    requestor = form.cleaned_data["email"]
+    requestor_meta = " ".join([
+        form.cleaned_data["first_name"],
+        form.cleaned_data["last_name"],
+        requestor,
+    ])
+    header = "\n".join([
+        f"[{key}] {value}" for key, value in [
+            ("Opened by", request.user),
+            ("Category", form.cleaned_data["category"]),
+            ("Resource", "Chameleon")
+        ]
+    ])
+
+    ticket_body = f"""{header}
+
+    {form.cleaned_data["problem_description"]}
+
+    ---
+    {requestor_meta}
+    """
+
+    ticket = rtModels.Ticket(
+        subject=form.cleaned_data["subject"],
+        problem_description=ticket_body,
+        requestor=requestor,
+        cc=form.cleaned_data.get("cc", []),
+    )
+
+    ticket_id = rt.createTicket(ticket)
+
+    if ticket_id < 0:
+        logger.error(f"Error creating ticket for {requestor}")
+        messages.error(request, (
+            "There was an error creating your ticket. Please try again."))
+        return None
+
+    logger.info(f"Created ticket #{ticket_id} for {requestor}")
+
+    if "attachment" in request.FILES:
+        attachment = request.FILES["attachment"]
+        mime_type, encoding = mimetypes.guess_type(attachment.name)
+        files = [(attachment.name, attachment, mime_type)]
+        success = rt.replyToTicket(ticket_id, files=files)
+        if not success:
+            logger.error(f"Error adding attachment to #{ticket_id}")
+
+    messages.success(request, (
+        f"Ticket #{ticket_id} has been successfully created. "
+        "We will respond to your request as soon as possible."))
+
+    return ticket_id
+
 
 def ticketcreate(request):
-    rt = rtUtil.DjangoRt()
-
+    # Don't require login, be nice and take to guest ticket page.
     if not request.user.is_authenticated():
-        return HttpResponseRedirect( reverse( 'djangoRT:ticketcreateguest'), )
+        return HttpResponseRedirect(reverse("djangoRT:ticketcreateguest"))
 
-    data = {
-        'email' : request.user.email,
-        'first_name' : request.user.first_name,
-        'last_name' : request.user.last_name
-    }
-
-    if request.method == 'POST':
+    if request.method == "POST":
         form = forms.TicketForm(request.POST, request.FILES)
-
-        if form.is_valid():
-            requestor_meta = '%s %s %s' % ( form.cleaned_data['first_name'], form.cleaned_data['last_name'], form.cleaned_data['email'] )
-            meta = (
-                ('Opened by', request.user),
-                ('Category', form.cleaned_data['category']),
-                ('Resource', 'Chameleon'),
-            )
-
-            header = '\n'.join('[%s] %s' % m for m in meta)
-            ticket_body = '%s\n\n%s\n\n---\n%s' % ( header, form.cleaned_data['problem_description'], requestor_meta )
-
-            region_list = []
-            for region in list(settings.OPENSTACK_AUTH_REGIONS.keys()):
-                try:
-                    token = get_token(request, region=region)
-                    region_list.append(get_openstack_data(request.user.username, token, region))
-                except Exception as err:
-                    logger.error(f'Failed to get OpenStack data for region {region}: {err}')
-
-            user_details = render_to_string('djangoRT/project_details.txt', {'regions': region_list})
-            ticket_body = ticket_body + user_details
-
-            ticket = rtModels.Ticket( subject = form.cleaned_data['subject'],
-                                      problem_description = ticket_body,
-                                      requestor = form.cleaned_data['email'],
-                                      cc = form.cleaned_data['cc'] )
-
-            logger.debug('Creating ticket for user: %s' % form.cleaned_data + ' with project details: ' + user_details)
-            ticket_id = rt.createTicket(ticket)
-
-            if ticket_id > -1:
-                if 'attachment' in request.FILES:
-                    rt.replyToTicket(ticket_id, files=([request.FILES['attachment'].name,\
-                        request.FILES['attachment'], mimetypes.guess_type(request.FILES['attachment'].name)],))
-                return HttpResponseRedirect( reverse( 'djangoRT:ticketdetail', args=[ ticket_id ]) )
-            else:
-                messages.error(request, 'There was an error creating your ticket. Please try again.')
-        else:
-            messages.error(request, 'Invalid')
+        ticket_id = _handle_ticket_form(request, form)
+        if ticket_id is not None:
+            return HttpResponseRedirect(reverse("djangoRT:ticketdetail", args=[ticket_id]))
     else:
         form = forms.TicketForm(initial={
-            'email' : request.user.email,
-            'first_name' : request.user.first_name,
-            'last_name' : request.user.last_name
+            "email": request.user.email,
+            "first_name": request.user.first_name,
+            "last_name": request.user.last_name
         })
-    return render(request, 'djangoRT/ticketCreate.html', { 'form' : form })
+
+    return render(request, "djangoRT/ticketCreate.html", {"form": form})
+
 
 def ticketcreateguest(request):
-    rt = rtUtil.DjangoRt()
-
-    data = {}
     if request.user.is_authenticated():
-        return HttpResponseRedirect( reverse( 'djangoRT:ticketcreate'), )
+        return HttpResponseRedirect(reverse("djangoRT:ticketcreate"))
 
-    if request.method == 'POST':
+    if request.method == "POST":
         form = forms.TicketGuestForm(request.POST, request.FILES)
-
-        if form.is_valid():
-            ticket = rtModels.Ticket(subject = form.cleaned_data['subject'],
-                    problem_description = form.cleaned_data['problem_description'],
-                    requestor = form.cleaned_data['email'])
-            ticket_id = rt.createTicket(ticket)
-
-            if ticket_id > -1:
-                if 'attachment' in request.FILES:
-                    rt.replyToTicket(ticket_id, files=([request.FILES['attachment'].name, request.FILES['attachment'], mimetypes.guess_type(request.FILES['attachment'].name)],))
-                messages.add_message(request, messages.SUCCESS, 'Ticket #%s has been successfully created. We will respond to your request as soon as possible.' % ticket_id)
-                form = forms.TicketGuestForm()
-                return render(request, 'djangoRT/ticketCreateGuest.html', { 'form': form })
-            else:
-                # make this cleaner probably
-                messages.error('An unexpected error occurred while creating your ticket. Please try again.')
-                data['first_name'] = form.cleaned_data['first_name']
-                data['last_name'] = form.cleaned_data['last_name']
-                data['requestor'] = ticket.requestor
-                data['subject'] = ticket.subject
-                data['problem_description'] = ticket.problem_description
-                data['cc'] = ticket.cc
-                form = forms.TicketGuestForm(data)
+        ticket_id = _handle_ticket_form(request, form)
+        if ticket_id is not None:
+            # Clear out the form
+            form = forms.TicketGuestForm()
+            return render(request, "djangoRT/ticketCreateGuest.html", {"form": form})
     else:
-        form = forms.TicketGuestForm(initial=data)
-    return render(request, 'djangoRT/ticketCreateGuest.html', { 'form' : form })
+        form = forms.TicketGuestForm()
+
+    return render(request, "djangoRT/ticketCreateGuest.html", {"form": form})
+
 
 @login_required
-def ticketreply(request, ticketId):
+def ticketreply(request, ticket_id):
     rt = rtUtil.DjangoRt()
+    ticket = rt.getTicket(ticket_id)
 
-    ticket = rt.getTicket(ticketId)
-    data = {}
-
-    if request.method == 'POST':
+    if request.method == "POST":
         form = forms.ReplyForm(request.POST, request.FILES)
 
         if form.is_valid():
-            if 'attachment' in request.FILES:
-                if rt.replyToTicket(ticketId, text=form.cleaned_data['reply'],\
-                    files=([request.FILES['attachment'].name, request.FILES['attachment'], mimetypes.guess_type(request.FILES['attachment'].name)],)):
-                    return HttpResponseRedirect(reverse( 'djangoRT:ticketdetail', args=[ ticketId ] ) )
-                else:
-                    data['reply'] = form.cleaned_data['reply']
-                    form = forms.ReplyForm(data)
+            if "attachment" in request.FILES:
+                attachment = request.FILES["attachment"]
+                mime_type, encoding = mimetypes.guess_type(attachment.name)
+                files = [(attachment.name, attachment, mime_type)]
+                success = rt.replyToTicket(ticket_id,
+                    text=form.cleaned_data["reply"], files=files)
+                if success:
+                    return HttpResponseRedirect(reverse("djangoRT:ticketdetail", args=[ticket_id]))
             else:
-                if rt.replyToTicket(ticketId, text=form.cleaned_data['reply']):
-                    return HttpResponseRedirect(reverse( 'djangoRT:ticketdetail', args=[ ticketId ] ) )
-                else:
-                    data['reply'] = form.cleaned_data['reply']
-                    form = forms.ReplyForm(data)
-
+                if rt.replyToTicket(ticket_id, text=form.cleaned_data["reply"]):
+                    return HttpResponseRedirect(reverse("djangoRT:ticketdetail", args=[ticket_id]))
     else:
-        form = forms.ReplyForm(initial=data)
-    return render(request, 'djangoRT/ticketReply.html', { 'ticket_id' : ticketId , 'ticket' : ticket, 'form' : form, 'hasAccess' : rt.hasAccess(ticketId, request.user.email) })
+        form = forms.ReplyForm()
+
+    return render(request, "djangoRT/ticketReply.html", {
+        "ticket_id": ticket_id,
+        "ticket": ticket,
+        "form": form,
+        "hasAccess": rt.hasAccess(ticket_id, request.user.email)
+    })
+
 
 @login_required
-def ticketclose(request, ticketId):
+def ticketclose(request, ticket_id):
     rt = rtUtil.DjangoRt()
+    ticket = rt.getTicket(ticket_id)
 
-    ticket = rt.getTicket(ticketId)
-    data = {}
-
-    if request.method == 'POST':
+    if request.method == "POST":
         form = forms.CloseForm(request.POST)
         if form.is_valid():
-            if rt.commentOnTicket(ticketId, text=form.cleaned_data['reply']) and rt.closeTicket(ticketId):
-                return HttpResponseRedirect(reverse( 'djangoRT:ticketdetail', args=[ ticketId ] ) )
+            reply = form.cleaned_data["reply"]
+            if (rt.commentOnTicket(ticket_id, text=reply) and
+                rt.closeTicket(ticket_id)):
+                return HttpResponseRedirect(reverse('djangoRT:ticketdetail', args=[ticket_id]))
     else:
-        form = forms.CloseForm(initial=data)
-    return render(request, 'djangoRT/ticketClose.html', { 'ticket_id' : ticketId , 'ticket' : ticket, 'form' : form, 'hasAccess' : rt.hasAccess(ticketId, request.user.email) })
+        form = forms.CloseForm()
+
+    return render(request, "djangoRT/ticketClose.html", {
+        "ticket_id": ticket_id ,
+        "ticket": ticket,
+        "form": form,
+        "hasAccess": rt.hasAccess(ticket_id, request.user.email),
+    })
 
 
 @login_required
-def ticketattachment(request, ticketId, attachmentId):
-    title, attachment = rtUtil.DjangoRt().getAttachment(ticketId, attachmentId)
-    if attachment['Headers']['Content-Disposition'] == 'inline':
-        return render(request, 'djangoRT/attachment.html', {'attachment' : attachment['Content'], 'ticketId' : ticketId, 'title' : title});
+def ticketattachment(request, ticket_id, attachment_id):
+    title, attachment = rtUtil.DjangoRt().getAttachment(ticket_id, attachment_id)
+    content = attachment["Content"]
+    content_disposition = attachment["Headers"]["Content-Disposition"]
+    content_type = attachment["Headers"]["Content-Type"]
+
+    if content_disposition == "inline":
+        return render(request, "djangoRT/attachment.html", {
+            "attachment": content,
+            "ticket_id" : ticket_id,
+            "title" : title,
+        })
     else:
-        response = HttpResponse(attachment['Content'], content_type=attachment['Headers']['Content-Type'])
-        response['Content-Disposition'] = attachment['Headers']['Content-Disposition']
+        response = HttpResponse(content, content_type=content_type)
+        response["Content-Disposition"] = content_disposition
         return response
+
 
 def get_openstack_data(username, unscoped_token, region):
     current_region = {}
@@ -234,6 +270,7 @@ def get_openstack_data(username, unscoped_token, region):
             logger.error(f'Failed to get active servers in {region} for {project.name}: {err}')
     return current_region
 
+
 def get_lease_info(psess):
     lease_list=[]
     blazar = blazar_client.Client('1', service_type='reservation', interface='publicURL', session=psess)
@@ -247,6 +284,7 @@ def get_lease_info(psess):
         lease_dict['id'] = lease.get('id')
         lease_list.append(lease_dict)
     return lease_list
+
 
 def get_server_info(psess):
     server_list=[]

--- a/djangoRT/views.py
+++ b/djangoRT/views.py
@@ -14,7 +14,7 @@ from dateutil import parser
 from chameleon.keystone_auth import admin_ks_client, get_user, project_scoped_session
 
 
-logger = logging.getLogger('default')
+logger = logging.getLogger("default")
 
 
 @login_required
@@ -22,10 +22,14 @@ def mytickets(request):
     rt = rtUtil.DjangoRt()
     show_resolved = "show_resolved" in request.GET
     tickets = rt.getUserTickets(request.user.email, show_resolved=show_resolved)
-    return render(request, "djangoRT/ticketList.html", {
-        "tickets": tickets,
-        "show_resolved": show_resolved,
-    })
+    return render(
+        request,
+        "djangoRT/ticketList.html",
+        {
+            "tickets": tickets,
+            "show_resolved": show_resolved,
+        },
+    )
 
 
 @login_required
@@ -36,17 +40,20 @@ def ticketdetail(request, ticket_id):
 
     # remove bogus "untitled" attachments
     for history in ticket_history:
-        history['Attachments'] = [
-            a for a in history['Attachments']
-            if not a[1].startswith('untitled (')
+        history["Attachments"] = [
+            a for a in history["Attachments"] if not a[1].startswith("untitled (")
         ]
 
-    return render(request, "djangoRT/ticketDetail.html", {
-        "ticket": ticket,
-        "ticket_history": ticket_history,
-        "ticket_id": ticket_id,
-        "hasAccess": rt.hasAccess(ticket_id, request.user.email)
-    })
+    return render(
+        request,
+        "djangoRT/ticketDetail.html",
+        {
+            "ticket": ticket,
+            "ticket_history": ticket_history,
+            "ticket_id": ticket_id,
+            "hasAccess": rt.hasAccess(ticket_id, request.user.email),
+        },
+    )
 
 
 def _handle_ticket_form(request, form):
@@ -66,25 +73,31 @@ def _handle_ticket_form(request, form):
         The ID of the ticket created, if successful. Returns None on error.
     """
     if not form.is_valid():
-        messages.error(request,
-            "The form is invalid, ensure all required fields are provided.")
+        messages.error(
+            request, "The form is invalid, ensure all required fields are provided."
+        )
         return None
 
     rt = rtUtil.DjangoRt()
 
     requestor = form.cleaned_data["email"]
-    requestor_meta = " ".join([
-        form.cleaned_data["first_name"],
-        form.cleaned_data["last_name"],
-        requestor,
-    ])
-    header = "\n".join([
-        f"[{key}] {value}" for key, value in [
-            ("Opened by", request.user),
-            ("Category", form.cleaned_data["category"]),
-            ("Resource", "Chameleon")
+    requestor_meta = " ".join(
+        [
+            form.cleaned_data["first_name"],
+            form.cleaned_data["last_name"],
+            requestor,
         ]
-    ])
+    )
+    header = "\n".join(
+        [
+            f"[{key}] {value}"
+            for key, value in [
+                ("Opened by", request.user),
+                ("Category", form.cleaned_data["category"]),
+                ("Resource", "Chameleon"),
+            ]
+        ]
+    )
 
     ticket_body = f"""{header}
 
@@ -105,8 +118,9 @@ def _handle_ticket_form(request, form):
 
     if ticket_id < 0:
         logger.error(f"Error creating ticket for {requestor}")
-        messages.error(request, (
-            "There was an error creating your ticket. Please try again."))
+        messages.error(
+            request, ("There was an error creating your ticket. Please try again.")
+        )
         return None
 
     logger.info(f"Created ticket #{ticket_id} for {requestor}")
@@ -119,9 +133,13 @@ def _handle_ticket_form(request, form):
         if not success:
             logger.error(f"Error adding attachment to #{ticket_id}")
 
-    messages.success(request, (
-        f"Ticket #{ticket_id} has been successfully created. "
-        "We will respond to your request as soon as possible."))
+    messages.success(
+        request,
+        (
+            f"Ticket #{ticket_id} has been successfully created. "
+            "We will respond to your request as soon as possible."
+        ),
+    )
 
     return ticket_id
 
@@ -135,13 +153,17 @@ def ticketcreate(request):
         form = forms.TicketForm(request.POST, request.FILES)
         ticket_id = _handle_ticket_form(request, form)
         if ticket_id is not None:
-            return HttpResponseRedirect(reverse("djangoRT:ticketdetail", args=[ticket_id]))
+            return HttpResponseRedirect(
+                reverse("djangoRT:ticketdetail", args=[ticket_id])
+            )
     else:
-        form = forms.TicketForm(initial={
-            "email": request.user.email,
-            "first_name": request.user.first_name,
-            "last_name": request.user.last_name
-        })
+        form = forms.TicketForm(
+            initial={
+                "email": request.user.email,
+                "first_name": request.user.first_name,
+                "last_name": request.user.last_name,
+            }
+        )
 
     return render(request, "djangoRT/ticketCreate.html", {"form": form})
 
@@ -176,22 +198,31 @@ def ticketreply(request, ticket_id):
                 attachment = request.FILES["attachment"]
                 mime_type, encoding = mimetypes.guess_type(attachment.name)
                 files = [(attachment.name, attachment, mime_type)]
-                success = rt.replyToTicket(ticket_id,
-                    text=form.cleaned_data["reply"], files=files)
+                success = rt.replyToTicket(
+                    ticket_id, text=form.cleaned_data["reply"], files=files
+                )
                 if success:
-                    return HttpResponseRedirect(reverse("djangoRT:ticketdetail", args=[ticket_id]))
+                    return HttpResponseRedirect(
+                        reverse("djangoRT:ticketdetail", args=[ticket_id])
+                    )
             else:
                 if rt.replyToTicket(ticket_id, text=form.cleaned_data["reply"]):
-                    return HttpResponseRedirect(reverse("djangoRT:ticketdetail", args=[ticket_id]))
+                    return HttpResponseRedirect(
+                        reverse("djangoRT:ticketdetail", args=[ticket_id])
+                    )
     else:
         form = forms.ReplyForm()
 
-    return render(request, "djangoRT/ticketReply.html", {
-        "ticket_id": ticket_id,
-        "ticket": ticket,
-        "form": form,
-        "hasAccess": rt.hasAccess(ticket_id, request.user.email)
-    })
+    return render(
+        request,
+        "djangoRT/ticketReply.html",
+        {
+            "ticket_id": ticket_id,
+            "ticket": ticket,
+            "form": form,
+            "hasAccess": rt.hasAccess(ticket_id, request.user.email),
+        },
+    )
 
 
 @login_required
@@ -203,18 +234,23 @@ def ticketclose(request, ticket_id):
         form = forms.CloseForm(request.POST)
         if form.is_valid():
             reply = form.cleaned_data["reply"]
-            if (rt.commentOnTicket(ticket_id, text=reply) and
-                rt.closeTicket(ticket_id)):
-                return HttpResponseRedirect(reverse('djangoRT:ticketdetail', args=[ticket_id]))
+            if rt.commentOnTicket(ticket_id, text=reply) and rt.closeTicket(ticket_id):
+                return HttpResponseRedirect(
+                    reverse("djangoRT:ticketdetail", args=[ticket_id])
+                )
     else:
         form = forms.CloseForm()
 
-    return render(request, "djangoRT/ticketClose.html", {
-        "ticket_id": ticket_id ,
-        "ticket": ticket,
-        "form": form,
-        "hasAccess": rt.hasAccess(ticket_id, request.user.email),
-    })
+    return render(
+        request,
+        "djangoRT/ticketClose.html",
+        {
+            "ticket_id": ticket_id,
+            "ticket": ticket,
+            "form": form,
+            "hasAccess": rt.hasAccess(ticket_id, request.user.email),
+        },
+    )
 
 
 @login_required
@@ -225,11 +261,15 @@ def ticketattachment(request, ticket_id, attachment_id):
     content_type = attachment["Headers"]["Content-Type"]
 
     if content_disposition == "inline":
-        return render(request, "djangoRT/attachment.html", {
-            "attachment": content,
-            "ticket_id" : ticket_id,
-            "title" : title,
-        })
+        return render(
+            request,
+            "djangoRT/attachment.html",
+            {
+                "attachment": content,
+                "ticket_id": ticket_id,
+                "title": title,
+            },
+        )
     else:
         response = HttpResponse(content, content_type=content_type)
         response["Content-Disposition"] = content_disposition
@@ -238,8 +278,8 @@ def ticketattachment(request, ticket_id, attachment_id):
 
 def get_openstack_data(username, unscoped_token, region):
     current_region = {}
-    current_region['name'] = region
-    current_region['projects'] = []
+    current_region["name"] = region
+    current_region["projects"] = []
     ks_admin = admin_ks_client(region=region)
     ks_user = get_user(ks_admin, username)
     projects = []
@@ -247,58 +287,64 @@ def get_openstack_data(username, unscoped_token, region):
         projects = ks_admin.projects.list(user=ks_user)
     for project in projects:
         current_project = {}
-        current_project['name'] = project.name
-        current_project['id'] = project.id
-        current_region['projects'].append(current_project)
+        current_project["name"] = project.name
+        current_project["id"] = project.id
+        current_region["projects"].append(current_project)
         try:
             psess = project_scoped_session(
-                unscoped_token=unscoped_token,
-                project_id=project.id,
-                region=region)
+                unscoped_token=unscoped_token, project_id=project.id, region=region
+            )
         except Exception:
             logger.error(
-                (f'Failed to authenticate to {region} as user {username}, '
-                 'skipping data collection'))
+                (
+                    f"Failed to authenticate to {region} as user {username}, "
+                    "skipping data collection"
+                )
+            )
             continue
         try:
-            current_project['leases'] = get_lease_info(psess)
+            current_project["leases"] = get_lease_info(psess)
         except Exception as err:
-            logger.error(f'Failed to get leases in {region} for {project.name}: {err}')
+            logger.error(f"Failed to get leases in {region} for {project.name}: {err}")
         try:
-            current_project['servers'] = get_server_info(psess)
+            current_project["servers"] = get_server_info(psess)
         except Exception as err:
-            logger.error(f'Failed to get active servers in {region} for {project.name}: {err}')
+            logger.error(
+                f"Failed to get active servers in {region} for {project.name}: {err}"
+            )
     return current_region
 
 
 def get_lease_info(psess):
-    lease_list=[]
-    blazar = blazar_client.Client('1', service_type='reservation', interface='publicURL', session=psess)
+    lease_list = []
+    blazar = blazar_client.Client(
+        "1", service_type="reservation", interface="publicURL", session=psess
+    )
     leases = blazar.lease.list()
     for lease in leases:
         lease_dict = {}
-        lease_dict['name'] = lease.get('name')
-        lease_dict['status'] = lease.get('status')
-        lease_dict['start_date'] = str(parser.parse(lease.get('start_date')))
-        lease_dict['end_date'] = str(parser.parse(lease.get('end_date')))
-        lease_dict['id'] = lease.get('id')
+        lease_dict["name"] = lease.get("name")
+        lease_dict["status"] = lease.get("status")
+        lease_dict["start_date"] = str(parser.parse(lease.get("start_date")))
+        lease_dict["end_date"] = str(parser.parse(lease.get("end_date")))
+        lease_dict["id"] = lease.get("id")
         lease_list.append(lease_dict)
     return lease_list
 
 
 def get_server_info(psess):
-    server_list=[]
-    nova = nova_client.Client('2', session=psess)
-    glance = glance_client('2', service_type='image', session=psess)
+    server_list = []
+    nova = nova_client.Client("2", session=psess)
+    glance = glance_client("2", service_type="image", session=psess)
     servers = nova.servers.list()
     for server in servers:
         server_dict = {}
-        server_dict['name'] = server.name
-        server_dict['status'] = str(server.status)
-        server_dict['created_date'] = str(parser.parse(server.created))
-        server_dict['id'] = server.id
-        image = glance.images.get(str(server.image['id']))
-        server_dict['image_name'] = str(image.name)
-        server_dict['image_id'] = str(image.id)
+        server_dict["name"] = server.name
+        server_dict["status"] = str(server.status)
+        server_dict["created_date"] = str(parser.parse(server.created))
+        server_dict["id"] = server.id
+        image = glance.images.get(str(server.image["id"]))
+        server_dict["image_name"] = str(image.name)
+        server_dict["image_id"] = str(image.id)
         server_list.append(server_dict)
     return server_list


### PR DESCRIPTION
This is a general refactor of the RT app, but just the view layer.
This moves most of the ticket handling logic to a core function, which
is called for both the logged in and guest case. Also fixes a bug where
mimetype was set to a tuple and not a string, which apparently caused
RT to throw its hands in the air and not process the file properly.

Added some better/more consistent error messaging, and ensured that
Python warnings were making it to the logging infra--the RT client uses
this mechanism to emit errors, so it's important we are seeing them.