### PR TITLE
Fix allowed_hosts and CSP=self for recaptcha

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -78,6 +78,10 @@ KEYCLOAK_REALM_NAME=chameleon
 KEYCLOAK_PORTAL_ADMIN_CLIENT_ID=portal-local-dev-admin
 KEYCLOAK_PORTAL_ADMIN_CLIENT_SECRET=
 
+# these are testing values, that will not work for production traffic
+RECAPTCHA_PUBLIC_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+RECAPTCHA_PRIVATE_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+
 # Legacy SSO
 SSO_CALLBACK_VALID_HOSTS=['dev.tacc.chameleoncloud.org','dev.uc.chameleoncloud.org']
 # Federated SSO

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -67,15 +67,17 @@ ZENODO_DEFAULT_ACCESS_TOKEN = os.getenv("ZENODO_DEFAULT_ACCESS_TOKEN")
 
 # TEMPLATE_DEBUG = DEBUG
 
-ALLOWED_HOSTS = [
+_default_allowed_hosts = [
     "127.0.0.1",
     "localhost",
     "chameleon.local",
     "chameleoncloud.org",
     "www.chameleoncloud.org",
-    "dev.chameleon.org",
+    "dev.chameleoncloud.org",
     "www.dev.chameleoncloud.org",
 ]
+
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", default=_default_allowed_hosts)
 
 # Application definition
 

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -784,6 +784,7 @@ BLOG_PLUGIN_TEMPLATE_FOLDERS = (
 )
 
 # Content-Security-Policy
+# Ensure that all items include self.
 CSP_FRAME_ANCESTORS = "'self'"  # Similar to X-Frame-Options: SAMEORIGIN
 CSP_SCRIPT_SRC = [
     "'self'",
@@ -792,8 +793,12 @@ CSP_SCRIPT_SRC = [
     "https://www.gstatic.com/recaptcha/",
     "'unsafe-inline'",
 ]
-CSP_CONNECT_SRC = ["'self'", "https://www.google-analytics.com"]
+CSP_CONNECT_SRC = [
+    "'self'",
+    "https://www.google-analytics.com",
+]
 CSP_FRAME_SRC = [
+    "'self'",
     "https://www.google.com/recaptcha/",
     "https://recaptcha.google.com/recaptcha/",
 ]


### PR DESCRIPTION
Adding recaptcha involved defining CSP_FRAME_SRC, but it was missing "self".
In addition, default keys have been defined for recaptcha. If used, recaptcha will always pass, and display a graphical warning.

In addition, the changes to ALLOWED_HOSTS from the recent domain change no longer allowed setting it from the .env file.
This fixes a typo, and allows setting via .env file.