### PR TITLE
quick-fix Allow requests from prod's host IP

### DIFF
--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -75,9 +75,10 @@ _default_allowed_hosts = [
     "www.chameleoncloud.org",
     "dev.chameleoncloud.org",
     "www.dev.chameleoncloud.org",
+    "129.114.97.96",
 ]
-
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", default=_default_allowed_hosts)
+ALLOWED_HOSTS = _default_allowed_hosts
+# ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", default=_default_allowed_hosts)
 
 # Application definition
 


### PR DESCRIPTION
Requests are coming from the host namespace on chameleon06
The "correct" way to handle this is to fix whatever is sending the
request to use the app docker network

A second issue is our usage of os.envion.get, since it has issues
with non-string data types.

We should use a library like `environs` to handle list types.