### PR TITLE
Add Openstack information in RT ticket description

### DIFF
--- a/djangoRT/templates/djangoRT/project_details.txt
+++ b/djangoRT/templates/djangoRT/project_details.txt
@@ -1,23 +1,57 @@
-
-
 ________________________________ Project Support Details ________________________________
 
 {% for region in regions %}
 Region: {{region.name}}
     {% for project in region.projects %}
-    Project: {{project.name}} ID: {{project.id}}
+    Project: {{project.charge_code}}
+        ID: {{project.id}}
         {% if project.leases %}
         Leases:{% for lease in project.leases %}
             {{lease.name}} - {{lease.status}}
                 Date Range: {{lease.start_date}} - {{lease.end_date}}
-                ID: {{lease.id}}{% endfor %}
+                ID: {{lease.id}}
+                Hosts:
+                    {% for host in lease.hosts %}
+                    {{ host.node_name }} (uid: {{ host.uid }}) {{ host.node_type }}
+                        provision_state: {{host.provision_state}}
+                        instance_uuid: {{host.instance_uuid}}
+                        {% if host.last_error %}
+                        last_error: {{host.last_error}}
+                        {% endif %}
+                    {% endfor %}
+                {% if lease.networks %}
+                Networks:{% for network in lease.networks %}
+                    id: {{ network.id }}
+                        physical_network: {{ network.physical_network }}
+                        segment_id: {{ network.segment_id }}{% endfor %} {% endif %}
+            {% endfor %}
+        {% else %}
+        {% if project.lease_error %}
+        Error getting leases for project
+        {% else %}
+        No recent leases for project
+        {% endif %}
         {% endif %}
         {% if project.servers %}
-        Instances:{% for server in project.servers %}
+        Instances:
+            {% for server in project.servers %}
             {{server.name}} - {{server.status}}
                 Created Date: {{server.created_date}}
                 Image: {{server.image_name}}   -  {{server.image_id}}
-                ID: {{server.id}}{% endfor %}
+                ID: {{server.id}}
+                {% for network in server.networks %}
+                Network: {{network.name}}
+                    {% for address in network.addresses %}
+                    {{address.type}} - {{address.addr}}
+                    {% endfor %}
+                {% endfor %}
+            {% endfor %}
+        {% else %}
+        {% if project.server_error %}
+        Error getting instances for project
+        {% else %}
+        No instances for project
+        {% endif %}
         {% endif %}
     {% endfor %}
 {% endfor %}

--- a/djangoRT/views.py
+++ b/djangoRT/views.py
@@ -105,7 +105,7 @@ def _handle_ticket_form(request, form):
     if request.user.username:
         region_list = get_region_list(request.user.username)
         openstack_user_data = render_to_string(
-            'djangoRT/project_details.txt', {'regions': region_list}
+            "djangoRT/project_details.txt", {"regions": region_list}
         )
     else:
         openstack_user_data = "\n---\n    No openstack data for anonymous user."
@@ -301,7 +301,7 @@ def get_region_list(username):
         try:
             region_list.append(get_openstack_data(username, region, projects))
         except Exception as err:
-            logger.error(f'Failed to get OpenStack data for region {region}: {err}')
+            logger.error(f"Failed to get OpenStack data for region {region}: {err}")
     return region_list
 
 

--- a/djangoRT/views.py
+++ b/djangoRT/views.py
@@ -1,18 +1,24 @@
+from django.conf import settings
 from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseRedirect
 from django.core.urlresolvers import reverse
 from djangoRT import rtUtil, forms, rtModels
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
+from django.template.loader import render_to_string
 import logging
 import mimetypes
+from datetime import datetime
 
 from novaclient import client as nova_client
 from blazarclient import client as blazar_client
 from glanceclient import Client as glance_client
+from ironicclient import client as ironic_client
 from dateutil import parser
-from chameleon.keystone_auth import admin_ks_client, get_user, project_scoped_session
-
+from chameleon.keystone_auth import admin_session, admin_ks_client
+from django.contrib.auth.models import User
+from projects.models import Project
+from util.keycloak_client import KeycloakClient
 
 logger = logging.getLogger("default")
 
@@ -78,8 +84,6 @@ def _handle_ticket_form(request, form):
         )
         return None
 
-    rt = rtUtil.DjangoRt()
-
     requestor = form.cleaned_data["email"]
     requestor_meta = " ".join(
         [
@@ -99,13 +103,25 @@ def _handle_ticket_form(request, form):
         ]
     )
 
+    if request.user.username:
+        region_list = get_region_list(request.user.username)
+        openstack_user_data = render_to_string('djangoRT/project_details.txt',
+                                               {'regions': region_list})
+    else:
+        openstack_user_data = "\n---\n    No openstack data for anonymous user."
+
     ticket_body = f"""{header}
 
     {form.cleaned_data["problem_description"]}
 
     ---
     {requestor_meta}
+
+
+    {remove_empty_lines(openstack_user_data)}
     """
+
+    rt = rtUtil.DjangoRt()
 
     ticket = rtModels.Ticket(
         subject=form.cleaned_data["subject"],
@@ -276,73 +292,163 @@ def ticketattachment(request, ticket_id, attachment_id):
         return response
 
 
-def get_openstack_data(username, unscoped_token, region):
+def get_region_list(username):
+    keycloak_client = KeycloakClient()
+    projects = keycloak_client.get_full_user_projects_by_username(username)
+
+    region_list = []
+    for region in list(settings.OPENSTACK_AUTH_REGIONS.keys()):
+        try:
+            region_list.append(
+                get_openstack_data(username, region, projects)
+            )
+        except Exception as err:
+            logger.error(
+                f'Failed to get OpenStack data for region {region}: {err}'
+            )
+    return region_list
+
+
+def get_openstack_data(username, region, projects):
+    admin_client = admin_ks_client(region)
+    admin_sess = admin_session(region)
+
     current_region = {}
     current_region["name"] = region
     current_region["projects"] = []
-    ks_admin = admin_ks_client(region=region)
-    ks_user = get_user(ks_admin, username)
-    projects = []
-    if ks_user:
-        projects = ks_admin.projects.list(user=ks_user)
+
+    # we know there is only going to be one domain
+    domains = list(admin_client.domains.list(name="chameleon"))
+    if not domains:
+        logger.error("Didn't find the domain \"chameleon\", skipping this site")
+        return current_region
+    domain_id = domains[0].id
+
+    ks_users_list = list(admin_client.users.list(name=username, domain=domain_id))
+    if len(ks_users_list) > 1:
+        logger.warning(f"Found {len(ks_users_list)} users for {username}, using the first.")
+    ks_user = ks_users_list[0]
+
+    all_ks_projects = {
+        ks_p.name: ks_p
+        for ks_p in admin_client.projects.list(domain=domain_id)
+    }
     for project in projects:
-        current_project = {}
-        current_project["name"] = project.name
-        current_project["id"] = project.id
-        current_region["projects"].append(current_project)
-        try:
-            psess = project_scoped_session(
-                unscoped_token=unscoped_token, project_id=project.id, region=region
-            )
-        except Exception:
-            logger.error(
-                (
-                    f"Failed to authenticate to {region} as user {username}, "
-                    "skipping data collection"
-                )
-            )
+        charge_code = project["name"]
+        # Project doesn't exist for this region
+        if charge_code not in all_ks_projects:
             continue
+        ks_project_id = all_ks_projects[charge_code].id
+        project_qs = Project.objects.filter(charge_code=charge_code)
+        project_list = list(project_qs)
+        if len(project_list) > 1:
+            raise Exception(f"More than one project found with charge code {charge_code}")
+        project = project_list[0]
+
+        current_project = {}
+        current_project["charge_code"] = project.charge_code
+        current_project["id"] = ks_project_id
+        current_region["projects"].append(current_project)
+
         try:
-            current_project["leases"] = get_lease_info(psess)
+            current_project["leases"] = get_lease_info(admin_sess, ks_user.id, ks_project_id)
         except Exception as err:
-            logger.error(f"Failed to get leases in {region} for {project.name}: {err}")
+            current_project["lease_error"] = True
+            logger.error(f"Failed to get leases in {region} for {project.title}: {err}")
         try:
-            current_project["servers"] = get_server_info(psess)
-        except Exception as err:
-            logger.error(
-                f"Failed to get active servers in {region} for {project.name}: {err}"
+            current_project["servers"] = get_server_info(
+                admin_sess, ks_project_id
             )
+        except Exception as err:
+            current_project["server_error"] = True
+            logger.error(
+                f"Failed to get active servers in {region} for {project.title}: {err}"
+            )
+
     return current_region
 
 
-def get_lease_info(psess):
+def get_lease_info(sess, user_id, project_id):
     lease_list = []
     blazar = blazar_client.Client(
-        "1", service_type="reservation", interface="publicURL", session=psess
+        "1", service_type="reservation", interface="publicURL", session=sess
     )
+    ironic = ironic_client.Client("1", session=sess)
     leases = blazar.lease.list()
     for lease in leases:
+        if lease.get("user_id") != user_id or lease.get("project_id") != project_id:
+            continue
+
+        # Ignore if more than 3 days out of date
+        end_date = parser.parse(lease.get("end_date"))
+        date_diff = datetime.utcnow() - end_date
+        if date_diff.days > 3:
+            continue
+
         lease_dict = {}
         lease_dict["name"] = lease.get("name")
         lease_dict["status"] = lease.get("status")
         lease_dict["start_date"] = str(parser.parse(lease.get("start_date")))
-        lease_dict["end_date"] = str(parser.parse(lease.get("end_date")))
+        lease_dict["end_date"] = str(end_date)
         lease_dict["id"] = lease.get("id")
+
+        lease_dict["hosts"] = []
+        resource_map = {r["id"]: r for r in blazar.host.list()}
+        for blazar_host in blazar.host.list_allocations():
+            if any(res["lease_id"] == lease_dict["id"] for res in blazar_host["reservations"]):
+                resource_host = resource_map[blazar_host["resource_id"]]
+                host = {
+                    "node_name": resource_host["node_name"],
+                    "uid": resource_host["uid"],
+                    "node_type": resource_host["node_type"]
+                }
+                node = ironic.node.get(resource_host["uid"])
+                host["provision_state"] = node.provision_state
+                host["instance_uuid"] = node.instance_uuid
+                host["last_error"] = node.last_error
+                lease_dict["hosts"].append(host)
+
+        lease_dict["networks"] = []
+        resource_map = {r["id"]: r for r in blazar.network.list()}
+        for network in blazar.network.list_allocations():
+            if any(res["lease_id"] == lease_dict["id"] for res in network["reservations"]):
+                lease_dict["networks"].append(resource_map[network["resource_id"]])
         lease_list.append(lease_dict)
     return lease_list
 
 
-def get_server_info(psess):
+def remove_empty_lines(string):
+    return "\n".join([line for line in string.split("\n") if len(line.strip()) > 0])
+
+
+def get_server_info(sess, project_id):
     server_list = []
-    nova = nova_client.Client("2", session=psess)
-    glance = glance_client("2", service_type="image", session=psess)
-    servers = nova.servers.list()
+    nova = nova_client.Client(
+        "2",
+        session=sess
+    )
+    glance = glance_client("2", service_type="image", session=sess)
+    servers = nova.servers.list(search_opts={'all_tenants': True})
     for server in servers:
+        if server.tenant_id != project_id:
+            continue
         server_dict = {}
         server_dict["name"] = server.name
         server_dict["status"] = str(server.status)
         server_dict["created_date"] = str(parser.parse(server.created))
         server_dict["id"] = server.id
+        server_dict["networks"] = []
+        for network in server.addresses.keys():
+            network_dict = {
+                "name": network,
+                "addresses": []
+            }
+            for address in server.addresses[network]:
+                network_dict["addresses"].append({
+                    "addr": address["addr"],
+                    "type": address["OS-EXT-IPS:type"],
+                })
+            server_dict["networks"].append(network_dict)
         image = glance.images.get(str(server.image["id"]))
         server_dict["image_name"] = str(image.name)
         server_dict["image_id"] = str(image.id)

--- a/poetry.lock
+++ b/poetry.lock
@@ -40,7 +40,7 @@ vine = "5.0.0"
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -337,6 +337,14 @@ python-versions = ">=3.6"
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 six = ">=1.10.0"
 wrapt = ">=1.7.0"
+
+[[package]]
+name = "decorator"
+version = "5.0.9"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "defusedxml"
@@ -873,6 +881,18 @@ python-versions = ">=3.5"
 django = ">=1.11"
 
 [[package]]
+name = "dogpile.cache"
+version = "1.1.3"
+description = "A caching front-end based on the Dogpile lock."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+decorator = ">=4.0.0"
+stevedore = ">=3.0.0"
+
+[[package]]
 name = "dynamic-rest"
 version = "2.0.0"
 description = "Adds Dynamic API support to Django REST Framework."
@@ -1027,6 +1047,14 @@ description = "Simple module to parse ISO 8601 dates"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "jmespath"
+version = "0.10.0"
+description = "JSON Matching Expressions"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "josepy"
@@ -1207,6 +1235,21 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "munch"
+version = "2.5.0"
+description = "A dot-accessible dictionary (a la JavaScript objects)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+testing = ["pytest", "coverage", "astroid (>=1.5.3,<1.6.0)", "pylint (>=1.7.2,<1.8.0)", "astroid (>=2.0)", "pylint (>=2.3.1,<2.4.0)"]
+yaml = ["PyYAML (>=5.1.0)"]
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -1242,6 +1285,31 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "openstacksdk"
+version = "0.57.0"
+description = "An SDK for building applications to work with OpenStack"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+appdirs = ">=1.3.0"
+cryptography = ">=2.7"
+decorator = ">=4.4.1"
+"dogpile.cache" = ">=0.6.5"
+importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
+iso8601 = ">=0.1.11"
+jmespath = ">=0.9.0"
+jsonpatch = ">=1.16,<1.20 || >1.20"
+keystoneauth1 = ">=3.18.0"
+munch = ">=2.1.0"
+netifaces = ">=0.10.4"
+os-service-types = ">=1.7.0"
+pbr = ">=2.0.0,<2.1.0 || >2.1.0"
+PyYAML = ">=3.13"
+requestsexceptions = ">=1.2.0"
+
+[[package]]
 name = "os-service-types"
 version = "1.7.0"
 description = "Python library for consuming OpenStack sevice-types-authority data"
@@ -1251,6 +1319,24 @@ python-versions = "*"
 
 [package.dependencies]
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
+
+[[package]]
+name = "osc-lib"
+version = "2.4.0"
+description = "OpenStackClient Library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cliff = ">=3.2.0"
+keystoneauth1 = ">=3.14.0"
+openstacksdk = ">=0.15.0"
+"oslo.i18n" = ">=3.15.3"
+"oslo.utils" = ">=3.33.0"
+pbr = ">=2.0.0,<2.1.0 || >2.1.0"
+simplejson = ">=3.5.1"
+stevedore = ">=1.20.0"
 
 [[package]]
 name = "oslo.config"
@@ -1596,11 +1682,12 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 name = "python-blazarclient"
-version = "2.2.1"
+version = "2.2.2.dev13"
 description = "Client for OpenStack Reservation Service"
 category = "main"
 optional = false
 python-versions = "*"
+develop = false
 
 [package.dependencies]
 Babel = ">=2.3.4,<2.4.0 || >2.4.0"
@@ -1612,6 +1699,12 @@ keystoneauth1 = ">=3.4.0"
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 PrettyTable = ">=0.7.1,<0.8"
 six = ">=1.10.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/ChameleonCloud/python-blazarclient"
+reference = "chameleoncloud/stable/train"
+resolved_reference = "0fd341693274f6d5bfe1e634bf499ab8ff227f09"
 
 [[package]]
 name = "python-cinderclient"
@@ -1661,6 +1754,32 @@ requests = ">=2.14.2"
 six = ">=1.10.0"
 warlock = ">=1.2.0,<2"
 wrapt = ">=1.7.0"
+
+[[package]]
+name = "python-ironicclient"
+version = "4.7.0"
+description = "OpenStack Bare Metal Provisioning API Client Library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+appdirs = ">=1.3.0"
+cliff = ">=2.8.0,<2.9.0 || >2.9.0"
+"dogpile.cache" = ">=0.8.0"
+jsonschema = ">=3.2.0"
+keystoneauth1 = ">=3.4.0"
+openstacksdk = ">=0.18.0"
+osc-lib = ">=2.0.0"
+"oslo.utils" = ">=3.33.0"
+pbr = ">=2.0.0,<2.1.0 || >2.1.0"
+PyYAML = ">=3.13"
+requests = ">=2.14.2"
+stevedore = ">=1.20.0"
+
+[package.extras]
+cli = ["python-openstackclient (>=3.12.0)"]
+test = ["coverage (>=4.0,!=4.4)", "ddt (>=1.0.1)", "fixtures (>=3.0.0)", "oslotest (>=3.2.0)", "python-openstackclient (>=3.12.0)", "requests-mock (>=1.2.0)", "stestr (>=1.0.0)", "tempest (>=17.1.0)", "testtools (>=2.2.0)"]
 
 [[package]]
 name = "python-jose"
@@ -1822,6 +1941,14 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "requestsexceptions"
+version = "1.4.0"
+description = "Import exceptions from potentially bundled packages in requests."
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "responses"
@@ -2040,7 +2167,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "e9073643dca76855d4d9dabadec882306d1304b7d17fc027bb2a00a306a98811"
+content-hash = "d19e8d6134c36133d74d97b3c0d0dd985e9d4beb0763404fc80272b19bed3766"
 
 [metadata.files]
 aldryn-apphooks-config = [
@@ -2106,24 +2233,36 @@ cffi = [
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55"},
     {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
     {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
     {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc"},
     {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
     {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
     {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76"},
     {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
     {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
     {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7"},
     {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
     {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
     {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
@@ -2184,6 +2323,10 @@ dataclasses = [
 debtcollector = [
     {file = "debtcollector-2.2.0-py3-none-any.whl", hash = "sha256:34663e5de257c67bf38827cfbea259c4d4ad27eba6b5a9d9242cb54076bfb4ad"},
     {file = "debtcollector-2.2.0.tar.gz", hash = "sha256:787981f4d235841bf6eb0467e23057fb1ac7ee24047c32028a8498b9128b6829"},
+]
+decorator = [
+    {file = "decorator-5.0.9-py3-none-any.whl", hash = "sha256:6e5c199c16f7a9f0e3a61a4a54b3d27e7dad0dbdde92b944426cb20914376323"},
+    {file = "decorator-5.0.9.tar.gz", hash = "sha256:72ecfba4320a893c53f9706bebb2d55c270c1e51a28789361aa93e4a21319ed5"},
 ]
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
@@ -2350,6 +2493,10 @@ djangorestframework = [
     {file = "djangorestframework-3.11.2-py3-none-any.whl", hash = "sha256:5cc724dc4b076463497837269107e1995b1fbc917468d1b92d188fd1af9ea789"},
     {file = "djangorestframework-3.11.2.tar.gz", hash = "sha256:a5967b68a04e0d97d10f4df228e30f5a2d82ba63b9d03e1759f84993b7bf1b53"},
 ]
+"dogpile.cache" = [
+    {file = "dogpile.cache-1.1.3-py3-none-any.whl", hash = "sha256:40a4dde7566d7ea731a7418ff8af6e40807ce2a5761a50336fd778b995acde66"},
+    {file = "dogpile.cache-1.1.3.tar.gz", hash = "sha256:6f0bcf97c73bfec1a7bf14e5a248488cee00c2d494bf63f3789ea6d95a57c1cf"},
+]
 dynamic-rest = [
     {file = "dynamic-rest-2.0.0.tar.gz", hash = "sha256:e2c7cef7db96ae8fd91bc3d387cd1e0a04c334bb6f1338a6db16d22d39549995"},
 ]
@@ -2401,6 +2548,10 @@ iso8601 = [
     {file = "iso8601-0.1.14-py2.py3-none-any.whl", hash = "sha256:e7e1122f064d626e17d47cd5106bed2c620cb38fe464999e0ddae2b6d2de6004"},
     {file = "iso8601-0.1.14.tar.gz", hash = "sha256:8aafd56fa0290496c5edbb13c311f78fa3a241f0853540da09d9363eae3ebd79"},
 ]
+jmespath = [
+    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
+    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
+]
 josepy = [
     {file = "josepy-1.8.0-py2.py3-none-any.whl", hash = "sha256:6d632fcdaf0bed09e33f81f13b10575d4f0b7c37319350b725454e04a41e6a49"},
     {file = "josepy-1.8.0.tar.gz", hash = "sha256:a5a182eb499665d99e7ec54bb3fe389f9cbc483d429c9651f20384ba29564269"},
@@ -2435,30 +2586,40 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:5c8c163396cc0df3fd151b927e74f6e4acd67160d6c33304e805b84293351d16"},
     {file = "lxml-4.6.3-cp35-cp35m-win32.whl", hash = "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2"},
     {file = "lxml-4.6.3-cp35-cp35m-win_amd64.whl", hash = "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4"},
     {file = "lxml-4.6.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:289e9ca1a9287f08daaf796d96e06cb2bc2958891d7911ac7cae1c5f9e1e0ee3"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d"},
+    {file = "lxml-4.6.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d916d31fd85b2f78c76400d625076d9124de3e4bda8b016d25a050cc7d603f24"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:820628b7b3135403540202e60551e741f9b6d3304371712521be939470b454ec"},
+    {file = "lxml-4.6.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:c47ff7e0a36d4efac9fd692cfa33fbd0636674c102e9e8d9b26e1b93a94e7617"},
     {file = "lxml-4.6.3-cp36-cp36m-win32.whl", hash = "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04"},
     {file = "lxml-4.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:92e821e43ad382332eade6812e298dc9701c75fe289f2a2d39c7960b43d1e92a"},
     {file = "lxml-4.6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0fbcf5565ac01dff87cbfc0ff323515c823081c5777a9fc7703ff58388c258c3"},
+    {file = "lxml-4.6.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:36108c73739985979bf302006527cf8a20515ce444ba916281d1c43938b8bb96"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:122fba10466c7bd4178b07dba427aa516286b846b2cbd6f6169141917283aae2"},
+    {file = "lxml-4.6.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:cdaf11d2bd275bf391b5308f86731e5194a21af45fbaaaf1d9e8147b9160ea92"},
     {file = "lxml-4.6.3-cp37-cp37m-win32.whl", hash = "sha256:3439c71103ef0e904ea0a1901611863e51f50b5cd5e8654a151740fde5e1cade"},
     {file = "lxml-4.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:4289728b5e2000a4ad4ab8da6e1db2e093c63c08bdc0414799ee776a3f78da4b"},
     {file = "lxml-4.6.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:26e761ab5b07adf5f555ee82fb4bfc35bf93750499c6c7614bd64d12aaa67927"},
+    {file = "lxml-4.6.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:e1cbd3f19a61e27e011e02f9600837b921ac661f0c40560eefb366e4e4fb275e"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791"},
+    {file = "lxml-4.6.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:1b38116b6e628118dea5b2186ee6820ab138dbb1e24a13e478490c7db2f326ae"},
     {file = "lxml-4.6.3-cp38-cp38-win32.whl", hash = "sha256:89b8b22a5ff72d89d48d0e62abb14340d9e99fd637d046c27b8b257a01ffbe28"},
     {file = "lxml-4.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:2a9d50e69aac3ebee695424f7dbd7b8c6d6eb7de2a2eb6b0f6c7db6aa41e02b7"},
     {file = "lxml-4.6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ce256aaa50f6cc9a649c51be3cd4ff142d67295bfc4f490c9134d0f9f6d58ef0"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23"},
+    {file = "lxml-4.6.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:3082c518be8e97324390614dacd041bb1358c882d77108ca1957ba47738d9d59"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969"},
+    {file = "lxml-4.6.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:6f12e1427285008fd32a6025e38e977d44d6382cf28e7201ed10d6c1698d2a9a"},
     {file = "lxml-4.6.3-cp39-cp39-win32.whl", hash = "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f"},
     {file = "lxml-4.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83"},
     {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},
@@ -2506,6 +2667,10 @@ msgpack = [
     {file = "msgpack-1.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:d8167b84af26654c1124857d71650404336f4eb5cc06900667a493fc619ddd9f"},
     {file = "msgpack-1.0.2.tar.gz", hash = "sha256:fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984"},
 ]
+munch = [
+    {file = "munch-2.5.0-py2.py3-none-any.whl", hash = "sha256:6f44af89a2ce4ed04ff8de41f70b226b984db10a91dcc7b9ac2efc1c77022fdd"},
+    {file = "munch-2.5.0.tar.gz", hash = "sha256:2d735f6f24d4dba3417fa448cae40c6e896ec1fdab6cdb5e6510999758a4dbd2"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -2544,9 +2709,17 @@ netifaces = [
     {file = "netifaces-0.10.9-cp37-cp37m-win_amd64.whl", hash = "sha256:86b8a140e891bb23c8b9cb1804f1475eb13eea3dbbebef01fcbbf10fbafbee42"},
     {file = "netifaces-0.10.9.tar.gz", hash = "sha256:2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3"},
 ]
+openstacksdk = [
+    {file = "openstacksdk-0.57.0-py3-none-any.whl", hash = "sha256:29bc1d95d117315b5ffb615f6db697b67a0d5d376c1c86ea685548a25e158788"},
+    {file = "openstacksdk-0.57.0.tar.gz", hash = "sha256:70302d9410badae7f88fd83c3056461f7f1033c157192f41a0134461d5e21822"},
+]
 os-service-types = [
     {file = "os-service-types-1.7.0.tar.gz", hash = "sha256:31800299a82239363995b91f1ebf9106ac7758542a1e4ef6dc737a5932878c6c"},
     {file = "os_service_types-1.7.0-py2.py3-none-any.whl", hash = "sha256:0505c72205690910077fb72b88f2a1f07533c8d39f2fe75b29583481764965d6"},
+]
+osc-lib = [
+    {file = "osc-lib-2.4.0.tar.gz", hash = "sha256:47029225c19a053a063736da390446debb5f14224dc60e92df7ca1b694625a9f"},
+    {file = "osc_lib-2.4.0-py3-none-any.whl", hash = "sha256:94faf037494ca5ebe17ec50ea06d97890bd47f7d7f30553c657cb66b0e6fd1ce"},
 ]
 "oslo.config" = [
     {file = "oslo.config-8.6.0-py3-none-any.whl", hash = "sha256:396bbd4f29f9679c56134d013ee2e9d03e4d4265360d91c21d30e8e26099f9d7"},
@@ -2617,6 +2790,7 @@ pillow = [
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4"},
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120"},
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291"},
     {file = "Pillow-8.2.0.tar.gz", hash = "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1"},
 ]
 pluggy = [
@@ -2702,10 +2876,7 @@ pytest = [
     {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
     {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
 ]
-python-blazarclient = [
-    {file = "python-blazarclient-2.2.1.tar.gz", hash = "sha256:dfd3e08e8a5be53630c1898fa56e2b0901e2bac224c7000e52c0f41cac63303d"},
-    {file = "python_blazarclient-2.2.1-py2.py3-none-any.whl", hash = "sha256:c0c81119f9a1b40de4851628e5089c0b884988e28d43ebe1fe6b6a05a4552e69"},
-]
+python-blazarclient = []
 python-cinderclient = [
     {file = "python-cinderclient-7.4.0.tar.gz", hash = "sha256:dec1998badfcf3af0a1bf47bbafd3a4f3415c18e1f9fbeceab77737da99b7c28"},
     {file = "python_cinderclient-7.4.0-py3-none-any.whl", hash = "sha256:7d127f5b5d1795b04b0322b4263302d613577d3bb69822b65a6c2fd14164d2fe"},
@@ -2717,6 +2888,10 @@ python-dateutil = [
 python-glanceclient = [
     {file = "python-glanceclient-2.17.1.tar.gz", hash = "sha256:342ae26f9be89fef5929384843b8f0601dd1149a618329774b846cb3540fac8e"},
     {file = "python_glanceclient-2.17.1-py2.py3-none-any.whl", hash = "sha256:e537fc6e17b5bae6ed9fa296544882d0131b92e6a676f03d14309851839096f0"},
+]
+python-ironicclient = [
+    {file = "python-ironicclient-4.7.0.tar.gz", hash = "sha256:8df53ac396bf657547e1532151f064729905c689cabe8641d932c804bbaf2afe"},
+    {file = "python_ironicclient-4.7.0-py3-none-any.whl", hash = "sha256:cb6ac7fb98ebd2f92493c69032cad57a7675f31956e5ef6f4090cedb66a1f137"},
 ]
 python-jose = [
     {file = "python-jose-3.2.0.tar.gz", hash = "sha256:4e4192402e100b5fb09de5a8ea6bcc39c36ad4526341c123d401e2561720335b"},
@@ -2750,18 +2925,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -2816,6 +2999,10 @@ regex = [
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+requestsexceptions = [
+    {file = "requestsexceptions-1.4.0-py2.py3-none-any.whl", hash = "sha256:3083d872b6e07dc5c323563ef37671d992214ad9a32b0ca4a3d7f5500bf38ce3"},
+    {file = "requestsexceptions-1.4.0.tar.gz", hash = "sha256:b095cbc77618f066d459a02b137b020c37da9f46d9b057704019c9f77dba3065"},
 ]
 responses = [
     {file = "responses-0.13.3-py2.py3-none-any.whl", hash = "sha256:b54067596f331786f5ed094ff21e8d79e6a1c68ef625180a7d34808d6f36c11b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,10 @@ mysqlclient = "^1.0"
 ply = "^3.11"
 pytas = {git = "https://github.com/ChameleonCloud/pytas"}
 python = "^3.6"
-python-blazarclient = "2.2.1"
+python-blazarclient = {git = "https://github.com/ChameleonCloud/python-blazarclient", branch = "chameleoncloud/stable/train"}
 python-cinderclient = "^7.2.0"
 python-glanceclient = "2.17.1"
+python-ironicclient = "4.7.0"
 python-keycloak-client = {git = "https://github.com/ChameleonCloud/python-keycloak-client"}
 python-keystoneclient = "3.21.0"
 python-memcached = "^1.59"

--- a/util/keycloak_client.py
+++ b/util/keycloak_client.py
@@ -115,10 +115,7 @@ class KeycloakClient:
         if not user:
             return []
         keycloakuser = self._user_admin(user["id"])
-
-        projects = [
-            project for project in keycloakuser.groups.all()
-        ]
+        projects = [project for project in keycloakuser.groups.all()]
         return projects
 
     def get_project_members(self, charge_code):

--- a/util/keycloak_client.py
+++ b/util/keycloak_client.py
@@ -110,6 +110,17 @@ class KeycloakClient:
         ]
         return project_charge_codes
 
+    def get_full_user_projects_by_username(self, username):
+        user = self.get_user_by_username(username)
+        if not user:
+            return []
+        keycloakuser = self._user_admin(user["id"])
+
+        projects = [
+            project for project in keycloakuser.groups.all()
+        ]
+        return projects
+
     def get_project_members(self, charge_code):
         group = self._lookup_group(charge_code)
         if not group:


### PR DESCRIPTION
Project, lease, and instance information is added to the end of
a ticket submitted by a logged in user. If a user is anonymous,
no information is displayed.

The version of python-blazarclient is switched to use Chameleon's
version of this library, so that `list_allocations` can be used.

Also, python-ironicclient is added as a new dependency to get the
provision state and instance uuid of a reserved node. This should
make it easier to find the issue when a node in a user's lease
won't launch.