### PR TITLE
Fix next param getting lost on login redirect

### DIFF
--- a/chameleon/os_login.py
+++ b/chameleon/os_login.py
@@ -25,7 +25,13 @@ LOG = logging.getLogger(__name__)
 @never_cache
 def custom_login(request, current_app=None, extra_context=None):
     if request.GET.get(settings.FORCE_OLD_LOGIN_EXPERIENCE_PARAM) != '1':
-        return HttpResponseRedirect(reverse('oidc_authentication_init'))
+        base_path = reverse('oidc_authentication_init')
+        # Preserve the next redirect if it exists
+        if "next" in request.GET:
+            next_path = request.GET["next"]
+            redir_path = f"{base_path}?next={next_path}"
+            return HttpResponseRedirect(redir_path)
+        return HttpResponseRedirect(base_path)
 
     login_return = login(request, current_app=None, extra_context=None)
     password = request.POST.get('password', False)


### PR DESCRIPTION
When redirected to login for a page that requires it, the next URL
parameter is used to remember the place. However, this was lost
when issuing a redirect to 'oidc_authentication_init'. This patch
fixes this issue by manually adding it to the oidc path when
generating the redirect.