### PR TITLE
Remove legacy account warning banner from dashboard

### DIFF
--- a/chameleon/templates/dashboard.html
+++ b/chameleon/templates/dashboard.html
@@ -8,18 +8,6 @@
 
 <h3>Dashboard</h3>
 
-{% if show_migration_info %}
-<div class="alert alert-info">
-  <p>
-    You have logged in via a federated identity, but you seem to have a legacy
-    account in the system.
-    <a href="{% url 'federation_migrate_account' %}">
-      Want to migrate your old account?
-    </a>
-  </p>
-</div>
-{% endif %}
-
 <div class="row">
   <div class="col-sm-6">
     <div class="panel panel-default">

--- a/chameleon/views.py
+++ b/chameleon/views.py
@@ -42,8 +42,6 @@ def dashboard(request):
     )
     context["active_projects"] = active_projects
 
-    context["show_migration_info"] = request.session.get("has_legacy_account", False)
-
     # open tickets...
     rt = rtUtil.DjangoRt()
     context["open_tickets"] = rt.getUserTickets(request.user.email)


### PR DESCRIPTION
This banner seems to be confusing to users, and is perhaps misleading.
