### PR TITLE
Add check to ignore reminder email for outage starting within one day

### DIFF
--- a/chameleon_mailman/tasks.py
+++ b/chameleon_mailman/tasks.py
@@ -35,15 +35,18 @@ def send_outage_reminders(crontab_frequency, send_outage_reminder_before):
 
             subject = "Outage Reminder: {}".format(outage.title)
             body = "<b>Outage Start:</b> {}<br /><br />".format(
-                outage.start_date.strftime("%Y-%m-%d %H:%M"))
+                outage.start_date.strftime("%Y-%m-%d %H:%M")
+            )
             body += "<b>Outage End:</b> {}<br /><br />".format(
-                outage.end_date.strftime("%Y-%m-%d %H:%M"))
+                outage.end_date.strftime("%Y-%m-%d %H:%M")
+            )
             body += outage.body
             sender = settings.DEFAULT_FROM_EMAIL
             recipients = settings.OUTAGE_NOTIFICATION_EMAIL.split(",")
 
-            mail_sent = send_mail(subject, strip_tags(body), sender,
-                                  recipients, html_message=body)
+            mail_sent = send_mail(
+                subject, strip_tags(body), sender, recipients, html_message=body
+            )
 
             if mail_sent:
                 outage.reminder_sent = now

--- a/chameleon_mailman/tasks.py
+++ b/chameleon_mailman/tasks.py
@@ -25,6 +25,12 @@ def send_outage_reminders(crontab_frequency, send_outage_reminder_before):
         seconds=(crontab_frequency * 60))
 
     for outage in upcoming_outages.all():
+        # Check for an outage scheduled close to start date
+        if outage.start_date < outage.created + timedelta(days=1):
+            outage.reminder_sent = outage.created
+            outage.save()
+            continue
+
         if send_window_min < outage.start_date < send_window_max:
 
             subject = 'Outage Reminder: {}'.format(outage.title)

--- a/chameleon_mailman/tasks.py
+++ b/chameleon_mailman/tasks.py
@@ -33,14 +33,14 @@ def send_outage_reminders(crontab_frequency, send_outage_reminder_before):
 
         if send_window_min < outage.start_date < send_window_max:
 
-            subject = 'Outage Reminder: {}'.format(outage.title)
+            subject = "Outage Reminder: {}".format(outage.title)
             body = "<b>Outage Start:</b> {}<br /><br />".format(
-                outage.start_date.strftime('%Y-%m-%d %H:%M'))
+                outage.start_date.strftime("%Y-%m-%d %H:%M"))
             body += "<b>Outage End:</b> {}<br /><br />".format(
-                outage.end_date.strftime('%Y-%m-%d %H:%M'))
+                outage.end_date.strftime("%Y-%m-%d %H:%M"))
             body += outage.body
             sender = settings.DEFAULT_FROM_EMAIL
-            recipients = settings.OUTAGE_NOTIFICATION_EMAIL.split(',')
+            recipients = settings.OUTAGE_NOTIFICATION_EMAIL.split(",")
 
             mail_sent = send_mail(subject, strip_tags(body), sender,
                                   recipients, html_message=body)

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 import pytz
 import re
 
+
 class NewsTag(models.Model):
     tag = models.TextField(max_length=50)
 
@@ -84,7 +85,9 @@ class Outage(News):
         ('SEV-2','SEV-2'),
         ('SEV-3','SEV-3'),
     )
-    severity = models.CharField(choices=SEVERITY_LEVEL, blank=False, default='', max_length=50)
+    severity = models.CharField(
+        choices=SEVERITY_LEVEL, blank=False, default="", max_length=50
+    )
 
     def save(self):
         # Do not send a reminder for outages scheduled within 1 day
@@ -92,7 +95,10 @@ class Outage(News):
         if self.start_date < now + timedelta(days=1):
             self.reminder_sent = now
         if not self.slug:
-            self.slug = '%s-%s' % (self.start_date.strftime('%y-%m-%d'), slugify(self.title))
+            self.slug = "%s-%s" % (
+                self.start_date.strftime("%y-%m-%d"),
+                slugify(self.title),
+            )
         super(Outage,self).save()
 
 class OutageUpdate(News):

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -4,6 +4,8 @@ from ckeditor.fields import RichTextField
 from django.template.defaultfilters import slugify
 from django.contrib import messages
 from cms.models.pluginmodel import CMSPlugin
+from datetime import datetime, timedelta
+import pytz
 import re
 
 class NewsTag(models.Model):
@@ -85,6 +87,10 @@ class Outage(News):
     severity = models.CharField(choices=SEVERITY_LEVEL, blank=False, default='', max_length=50)
 
     def save(self):
+        # Do not send a reminder for outages scheduled within 1 day
+        now = datetime.now(pytz.utc)
+        if self.start_date < now + timedelta(days=1):
+            self.reminder_sent = now
         if not self.slug:
             self.slug = '%s-%s' % (self.start_date.strftime('%y-%m-%d'), slugify(self.title))
         super(Outage,self).save()

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -91,9 +91,6 @@ class Outage(News):
 
     def save(self):
         # Do not send a reminder for outages scheduled within 1 day
-        now = datetime.now(pytz.utc)
-        if self.start_date < now + timedelta(days=1):
-            self.reminder_sent = now
         if not self.slug:
             self.slug = "%s-%s" % (
                 self.start_date.strftime("%y-%m-%d"),

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -4,10 +4,7 @@ from ckeditor.fields import RichTextField
 from django.template.defaultfilters import slugify
 from django.contrib import messages
 from cms.models.pluginmodel import CMSPlugin
-from datetime import datetime, timedelta
-import pytz
 import re
-
 
 class NewsTag(models.Model):
     tag = models.TextField(max_length=50)
@@ -90,7 +87,6 @@ class Outage(News):
     )
 
     def save(self):
-        # Do not send a reminder for outages scheduled within 1 day
         if not self.slug:
             self.slug = "%s-%s" % (
                 self.start_date.strftime("%y-%m-%d"),

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -99,7 +99,7 @@ class Outage(News):
                 self.start_date.strftime("%y-%m-%d"),
                 slugify(self.title),
             )
-        super(Outage,self).save()
+        super(Outage, self).save()
 
 class OutageUpdate(News):
     original_item = models.ForeignKey(Outage)

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -101,6 +101,7 @@ class Outage(News):
             )
         super(Outage, self).save()
 
+
 class OutageUpdate(News):
     original_item = models.ForeignKey(Outage)
 


### PR DESCRIPTION
When sending outage reminders, `reminder_sent` is checked for null. When an outage is saved that is scheduled for
within 1 day, we set this to the current date to avoid the task sending an email in the future.