### PR TITLE
Remove legacy plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,6 @@ RUN pip install --upgrade pip && \
 COPY poetry.lock pyproject.toml /setup/
 ENV POETRY_VIRTUALENVS_CREATE=false
 RUN poetry install --no-dev --no-root
-RUN pip install git+https://github.com/ChameleonCloud/aldryn-bootstrap3.git
-RUN pip install git+https://github.com/ChameleonCloud/djangocms-teaser.git
 
 RUN mkdir /var/log/django
 VOLUME ["/media"]

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -107,8 +107,6 @@ INSTALLED_APPS = (
     # django-cms
     #
     "cms",
-    "aldryn_bootstrap3",
-    "djangocms_teaser",
     "menus",
     "sekizai",
     "treebeard",


### PR DESCRIPTION
I've updated the cms pages that were using these, and now they can be removed.