### PR TITLE
Fix sharing portal project sharing and filter deleted projects

### DIFF
--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -85,7 +85,7 @@ def check_view_permission(func):
                     for p in mapper.get_user_projects(
                         request.user.username, fetch_balance=False)
                 ]
-                if any(p.charge_code in user_projects for p in project_shares):
+                if any(p.project.charge_code in user_projects for p in project_shares):
                     return all_versions
 
         # NOTE(jason): It is important that this check go last. Visibility b/c

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -84,7 +84,7 @@ def check_view_permission(func):
             if project_shares:
                 mapper = ProjectAllocationMapper(request)
                 user_projects = [
-                    p['chargeCode']
+                    p["chargeCode"]
                     for p in mapper.get_user_projects(
                         request.user.username, fetch_balance=False
                     )

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -86,7 +86,8 @@ def check_view_permission(func):
                 user_projects = [
                     p['chargeCode']
                     for p in mapper.get_user_projects(
-                        request.user.username, fetch_balance=False)
+                        request.user.username, fetch_balance=False
+                    )
                 ]
                 if any(p.project.charge_code in user_projects for p in project_shares):
                     return all_versions
@@ -196,9 +197,12 @@ def _fetch_artifacts(filters):
     to act over the artifact versions collection; this is used to render stats
     in some places.
     """
-    return (Artifact.objects.prefetch_related('artifact_versions').filter(filters)
+    return (
+        Artifact.objects.prefetch_related("artifact_versions")
+        .filter(filters)
         .filter(deleted=False)
-        .annotate(num_versions=Count('artifact_versions')))
+        .annotate(num_versions=Count("artifact_versions"))
+    )
 
 
 @check_edit_permission

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -60,6 +60,9 @@ def check_edit_permission(func):
 
 def check_view_permission(func):
     def can_view(request, artifact):
+        if artifact.deleted:
+            return []
+
         all_versions = list(artifact.versions)
 
         if artifact.is_public:
@@ -194,6 +197,7 @@ def _fetch_artifacts(filters):
     in some places.
     """
     return (Artifact.objects.prefetch_related('artifact_versions').filter(filters)
+        .filter(deleted=False)
         .annotate(num_versions=Count('artifact_versions')))
 
 


### PR DESCRIPTION
This fixes `'ShareTarget' object has no attribute 'charge_code'` error when an artifact was shared with a project.

It also filters deleted artifacts. There is no UI to do this, but an admin can set this via the admin panel.