### PR TITLE
Allow deleting entire Trovi artifact

### DIFF
--- a/sharing_portal/static/sharing_portal/artifacts.css
+++ b/sharing_portal/static/sharing_portal/artifacts.css
@@ -216,6 +216,17 @@
     border-radius: 0.5rem;
 }
 
+.artifactVersions__Header {
+    display: flex;
+} .artifactVersions__Header > h4 {
+    flex: 1;
+} .artifactVersions__Header > form {
+    display: inline;
+    /* Align delete_all button with trash icon */
+    margin-right: 6%;
+    align-self: center;
+}
+
 .artifactVersion__title {
     display: flex;
     flex: 1;

--- a/sharing_portal/templates/sharing_portal/edit.html
+++ b/sharing_portal/templates/sharing_portal/edit.html
@@ -37,11 +37,16 @@
 
   <div class="layoutGrid__side">
     <div class="artifactVersions">
-      <div style="display: flex">
-        <h4 style="flex: 1"><i class="fa fa-files-o"></i> Versions</h4>
-        <form role="form" method="post" style="display:inline; margin-right: 6%">
+      <div class="artifactVersions__Header">
+        <h4><i class="fa fa-files-o"></i> Versions</h4>
+        <form role="form" method="post">
           {% csrf_token %}
-          <button class="btn btn-danger" type="submit" name="delete_all" >Delete All</button>
+          <button class="btn btn-xs btn-danger" type="submit" name="delete_all"
+            {% if artifact.doi %}disabled title="Cannot delete artifact published with DOI"
+            {% else %}title="Delete the entire Trovi artifact"
+            {% endif %}>
+            Delete All
+          </button>
         </form>
       </div>
       <form method="post">

--- a/sharing_portal/templates/sharing_portal/edit.html
+++ b/sharing_portal/templates/sharing_portal/edit.html
@@ -37,7 +37,13 @@
 
   <div class="layoutGrid__side">
     <div class="artifactVersions">
-      <h4><i class="fa fa-files-o"></i> Versions</h4>
+      <div style="display: flex">
+        <h4 style="flex: 1"><i class="fa fa-files-o"></i> Versions</h4>
+        <form role="form" method="post" style="display:inline; margin-right: 6%">
+          {% csrf_token %}
+          <button class="btn btn-danger" type="submit" name="delete_all" >Delete All</button>
+        </form>
+      </div>
       <form method="post">
         {% csrf_token %}
         <ol>
@@ -70,6 +76,20 @@
                 event.preventDefault();
               }
             });
+          })
+          const deleteAllButton = document.querySelector('[name=delete_all]');
+          deleteAllButton.addEventListener('click', (event) => {
+            let warning = "WARNING! You are about to delete your entire Trovi artifact! " +
+              "Are you sure you want to do this? Type the name of the artifact to confirm:";
+            while (true) {
+              let nameInput = prompt(warning);
+              if (nameInput === null) {  // cancel
+                event.preventDefault();
+                break;
+              } else if (nameInput === "{{ artifact.title }}") {
+                break;
+              }
+            }
           });
         });
       })();

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -261,9 +261,9 @@ def edit_artifact(request, artifact):
                         messages.ERROR,
                         "Could not delete all artifact versions.",
                     )
-                return HttpResponseRedirect(
-                    reverse("sharing_portal:edit", args=[artifact.pk])
-                )
+                    return HttpResponseRedirect(
+                        reverse("sharing_portal:edit", args=[artifact.pk])
+                    )
 
             try:
                 artifact.delete()

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -244,7 +244,7 @@ def edit_artifact(request, artifact):
             for version in artifact.versions:
                 if not _delete_artifact_version(request, version):
                     messages.add_message(request, messages.ERROR,
-                                         f"Could not delete all artifact versions.")
+                                         "Could not delete all artifact versions.")
                 return HttpResponseRedirect(
                     reverse('sharing_portal:edit', args=[artifact.pk]))
 

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -231,6 +231,7 @@ def _delete_artifact_version(request, version):
         )
         return False
 
+
 @check_edit_permission
 @login_required
 def edit_artifact(request, artifact):

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -210,17 +210,26 @@ def _delete_artifact_version(request, version):
         try:
             version.delete()
         except Exception as e:
-            messages.add_message(request, messages.ERROR,
-                                 f'Error deleting artifact version {version}: {str(e)}')
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"Error deleting artifact version {version}: {str(e)}",
+            )
             return False
-        messages.add_message(request, messages.SUCCESS,
-                             f'Successfully deleted artifact version {version}.')
+        messages.add_message(
+            request,
+            messages.SUCCESS,
+            f"Successfully deleted artifact version {version}.",
+        )
         return True
     else:
-        messages.add_message(request, messages.ERROR,
-                             f'Cannot delete versions '
-                             f'already assigned a DOI. ({version})')
+        messages.add_message(
+            request,
+            messages.ERROR,
+            f"Cannot delete versions " f"already assigned a DOI. ({version})",
+        )
         return False
+
 
 @check_edit_permission
 @login_required
@@ -234,34 +243,47 @@ def edit_artifact(request, artifact):
                 version = artifact.versions.get(pk=version_id)
                 _delete_artifact_version(request, version)
             except ArtifactVersion.DoesNotExist:
-                messages.add_message(request, messages.ERROR,
-                    'Artifact version {} does not exist'.format(version_id))
+                messages.add_message(
+                    request,
+                    messages.ERROR,
+                    "Artifact version {} does not exist".format(version_id),
+                )
             # Return to edit form
             return HttpResponseRedirect(
-                reverse('sharing_portal:edit', args=[artifact.pk]))
+                reverse("sharing_portal:edit", args=[artifact.pk])
+            )
 
         elif "delete_all" in request.POST:
             for version in artifact.versions:
                 if not _delete_artifact_version(request, version):
-                    messages.add_message(request, messages.ERROR,
-                                         "Could not delete all artifact versions.")
+                    messages.add_message(
+                        request,
+                        messages.ERROR,
+                        "Could not delete all artifact versions.",
+                    )
                 return HttpResponseRedirect(
-                    reverse('sharing_portal:edit', args=[artifact.pk]))
+                    reverse("sharing_portal:edit", args=[artifact.pk])
+                )
 
             try:
                 artifact.delete()
             except Exception as e:
-                messages.add_message(request, messages.ERROR,
-                                     f"Could not delete artifact: {str(e)}")
+                messages.add_message(
+                    request, messages.ERROR, f"Could not delete artifact: {str(e)}"
+                )
                 # Return to edit form
                 return HttpResponseRedirect(
-                    reverse('sharing_portal:edit', args=[artifact.pk]))
+                    reverse("sharing_portal:edit", args=[artifact.pk])
+                )
 
-            messages.add_message(request, messages.SUCCESS,
-                                 f"Successfully deleted artifact {artifact.title}.")
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                f"Successfully deleted artifact {artifact.title}.",
+            )
 
             # Return to Trovi home page
-            return HttpResponseRedirect(reverse('sharing_portal:index_all'))
+            return HttpResponseRedirect(reverse("sharing_portal:index_all"))
 
         artifact, errors = _handle_artifact_forms(request, form)
         if errors:

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -205,6 +205,23 @@ def _fetch_artifacts(filters):
     )
 
 
+def _delete_artifact_version(request, version):
+    if not version.doi:
+        try:
+            version.delete()
+        except Exception as e:
+            messages.add_message(request, messages.ERROR,
+                                 f'Error deleting artifact version {version}: {str(e)}')
+            return False
+        messages.add_message(request, messages.SUCCESS,
+                             f'Successfully deleted artifact version {version}.')
+        return True
+    else:
+        messages.add_message(request, messages.ERROR,
+                             f'Cannot delete versions '
+                             f'already assigned a DOI. ({version})')
+        return False
+
 @check_edit_permission
 @login_required
 def edit_artifact(request, artifact):
@@ -215,19 +232,34 @@ def edit_artifact(request, artifact):
             version_id = request.POST.get("delete_version")
             try:
                 version = artifact.versions.get(pk=version_id)
-                if not version.doi:
-                    version.delete()
-                    messages.add_message(request, messages.SUCCESS,
-                        'Successfully deleted artifact version.')
-                else:
-                    messages.add_message(request, messages.ERROR,
-                        'Cannot delete versions already assigned a DOI.')
+                _delete_artifact_version(request, version)
             except ArtifactVersion.DoesNotExist:
                 messages.add_message(request, messages.ERROR,
                     'Artifact version {} does not exist'.format(version_id))
             # Return to edit form
             return HttpResponseRedirect(
                 reverse('sharing_portal:edit', args=[artifact.pk]))
+
+        elif "delete_all" in request.POST:
+            for version in artifact.versions:
+                if not _delete_artifact_version(request, version):
+                    messages.add_message(request, messages.ERROR,
+                                         f"Could not delete all artifact versions.")
+
+            try:
+                artifact.delete()
+            except Exception as e:
+                messages.add_message(request, messages.ERROR,
+                                     f"Could not delete artifact: {str(e)}")
+                # Return to edit form
+                return HttpResponseRedirect(
+                    reverse('sharing_portal:edit', args=[artifact.pk]))
+
+            messages.add_message(request, messages.SUCCESS,
+                                 f"Successfully deleted artifact {artifact.title}.")
+
+            # Return to Trovi home page
+            return HttpResponseRedirect(reverse('sharing_portal:index_all'))
 
         artifact, errors = _handle_artifact_forms(request, form)
         if errors:

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -232,6 +232,7 @@ def _delete_artifact_version(request, version):
         return False
 
 
+
 @check_edit_permission
 @login_required
 def edit_artifact(request, artifact):

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -245,6 +245,8 @@ def edit_artifact(request, artifact):
                 if not _delete_artifact_version(request, version):
                     messages.add_message(request, messages.ERROR,
                                          f"Could not delete all artifact versions.")
+                return HttpResponseRedirect(
+                    reverse('sharing_portal:edit', args=[artifact.pk]))
 
             try:
                 artifact.delete()

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -232,7 +232,6 @@ def _delete_artifact_version(request, version):
         return False
 
 
-
 @check_edit_permission
 @login_required
 def edit_artifact(request, artifact):


### PR DESCRIPTION
Adds a button to delete all artifact versions, and then the artifact itself. The button is accessible via the edit page for a given artifact. Currently, it will launch a JavaScript prompt that will ask for the name of the artifact to confirm its deletion. It will wait until the correct name is input, or the prompt is cancelled.

This achieves the desired function of the confirmation prompt, but I think it would be more ideal to mimic the behavior of other websites (such as deleting a repo on GitHub) where a prompt pops up, and the confirm button is greyed out until the text in the box matches the desired input. I think this is more familiar to users, but unfortunately seems like a challenging front end task, which I am not very familiar with.

Some additional refactoring to the version deletion code has been done on the backend as well, which should make error reporting for delete_version and delete_all more user-friendly.

![image](https://user-images.githubusercontent.com/14908880/134600229-472da61b-e505-4172-97b0-bc4a93b5f728.png)

![image](https://user-images.githubusercontent.com/14908880/134563718-6bed8350-6c41-4fd0-b979-a2a37629b0b9.png)

![image](https://user-images.githubusercontent.com/14908880/134563813-c4366029-519d-4a26-aab4-5bf684e56a77.png)

Button is disabled if artifact has DOI:
![image](https://user-images.githubusercontent.com/14908880/134600288-d8748dcf-a59e-4e2c-8c99-a04be5c94945.png)
