### PR TITLE
Clean up docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./media:/media
       - static:/static
     ports:
-      - 127.0.0.1:8890:${PORTAL_PORT}
+      - "127.0.0.1:8890:${PORTAL_PORT}"
     entrypoint: ["python3", "manage.py"]
     command: ["runserver", "0.0.0.0:${PORTAL_PORT}"]
     depends_on:
@@ -23,13 +23,9 @@ services:
   referenceapi:
     image: docker.chameleoncloud.org/referenceapi:latest
     ports:
-      - 127.0.0.1:8891:8000
+      - "127.0.0.1:8891:8000"
   mysql:
     image: mariadb:10
-    restart: "no"
-    healthcheck:
-      test: [CMD, mysqladmin, "-u${DB_USER}", "-p${DB_PASSWORD}", --silent, status]
-      interval: "1s"
     volumes:
       - ./db:/docker-entrypoint-initdb.d
     restart: on-failure
@@ -45,7 +41,7 @@ services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     ports:
-      - 127.0.0.1:8889:80
+      - "127.0.0.1:8889:80"
     environment:
       - PMA_HOST=mysql
       - PMA_PORT=3306
@@ -73,12 +69,12 @@ services:
     volumes:
       - .:/project
     ports:
-      - 127.0.0.1:9000:9000
+      - "127.0.0.1:9000:9000"
   mail:
     image: mailhog/mailhog:latest
     restart: always
     ports:
-    - 127.0.0.1:8025:8025
+    - "127.0.0.1:8025:8025"
 
 volumes:
   static:


### PR DESCRIPTION
The docker-compose.yml file we use for development had a couple issues with it. The `mysql` service had some duplicated keys, and port mappings were not quote-wrapped, which might confuse some tools.
