### PR TITLE
display institution and country of the pi

### DIFF
--- a/allocations/templates/allocations/index.html
+++ b/allocations/templates/allocations/index.html
@@ -100,6 +100,8 @@
                                         <i class="fa fa-envelope-o"></i> [[project.pi.email]]
                                     </a>
                                     <br>Username: [[ project.pi.username]]
+                                    <br>Institution: [[ project.pi.institution]]
+                                    <br>Country: [[ project.pi.country]]
                                 </td>
                             </tr>
                             <tr>

--- a/projects/templates/projects/allocation.html
+++ b/projects/templates/projects/allocation.html
@@ -1,5 +1,5 @@
 {% if alloc.up_for_renewal and not project.has_approved_allocations and not project.has_pending_allocations %}
-<tr>
+<tr class="allocation allocation-{{ alloc.status|lower }}">
   <td colspan="7">
     <small class="alert alert-warning">
       <i class="fa fa-warning"></i>

--- a/projects/templates/projects/create_project.html
+++ b/projects/templates/projects/create_project.html
@@ -19,6 +19,42 @@
   
   {% bootstrap_form allocation_form %}
   
+  <p>
+  <b>Are you from an international research institution?</b>
+  <button type="button" class="btn btn-sm btn-primary" data-toggle="modal" data-target="#internationalModal">
+  	Yes
+  </button>
+  
+  <!-- Modal -->
+  <div class="modal fade" id="internationalModal" role="dialog" aria-labelledby="internationalModalLabel" aria-hidden="true" style="padding-top:10%;">
+    <div class="modal-dialog" role="document" style="width: 70%;">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" id="internationalModalLabel">Thank you for your interest in Chameleon!</h4>
+        </div>
+        <div class="modal-body">
+        <p>
+        While we would like to serve as many international collaborators as possible, the intent of the system is to serve 
+        the primarily US community of researchers and their collaborators. Our capability to support international PIs is 
+        thus limited and for this reason, we are vetting project requests from international collaborators more closely. 
+        </p>
+        <p>
+        Could you tell us more in the Resource Justification section about what types of resources you are likely to need 
+        (in particular, our KVM cloud or other resources), and what contributions you are planning to make to the Chameleon 
+        community (e.g., provide electronic packaging of experiments, class materials, etc.)? If you are working with US 
+        collaborators or a project that already uses Chameleon, please make sure to provide the details as they will be 
+        instrumental in our decision.
+        </p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  </p>
+  
   {% include "projects/fundings.html" %}
 
   <div class="form-group">

--- a/util/keycloak_client.py
+++ b/util/keycloak_client.py
@@ -105,6 +105,15 @@ class KeycloakClient:
         else:
             return None
 
+    def get_all_users_attributes(self):
+        keycloakusers = self._users_admin()
+
+        result = {}
+        for user in keycloakusers.all(max_results=-1):
+            result[user["username"]] = user.get("attributes")
+
+        return result
+
     def get_user_projects_by_username(self, username):
         user = self.get_user_by_username(username)
         if not user:


### PR DESCRIPTION
we'd like to grant pi eligibility to international researchers,
but have more restrict rules to approve their allocation requests.
in order to easily tell if the project belongs to an international
pi, the allocation admin page will display the institution and country
of the pi. The information is collected from keycloak.