### PR TITLE
fix for getting resource id

### DIFF
--- a/allocations/tasks.py
+++ b/allocations/tasks.py
@@ -287,13 +287,14 @@ def _fill_charge_tmp_resource_ids():
     for region in charge_by_region.keys():
         db = utils.connect_to_region_db(region)
         for charge in charge_by_region[region]:
-            items = charge.resource_id.split("/")
+            items = charge.resource_id.split("/", maxsplit=4)
             project_id = items[1]
             user_id = items[2]
             lease_start_date = items[3]
+            name = items[4]
             resource_type = charge.resource_type
             resource_id = utils.get_resource_id(
-                db, project_id, user_id, lease_start_date, resource_type
+                db, project_id, user_id, lease_start_date, resource_type, name
             )
             if resource_id:
                 charge.resource_id = resource_id

--- a/allocations/utils.py
+++ b/allocations/utils.py
@@ -154,7 +154,9 @@ def get_floatingip_charges_by_ids(db, resource_ids=None):
     return parse_db_query(cursor.fetchall())
 
 
-def get_resource_id(db, project_id, user_id, lease_start_date, resource_type):
+def get_resource_id(
+    db, project_id, user_id, lease_start_date, resource_type, lease_name
+):
     cursor = db.cursor(MySQLdb.cursors.DictCursor)
     cursor.execute(
         """
@@ -165,12 +167,14 @@ def get_resource_id(db, project_id, user_id, lease_start_date, resource_type):
         AND user_id = %(user_id)s
         AND start_date = %(start_date)s
         AND resource_type = %(resource_type)s
+        AND name = %(lease_name)s
         """,
         {
             "project_id": project_id,
             "user_id": user_id,
             "start_date": lease_start_date,
             "resource_type": resource_type,
+            "lease_name": lease_name,
         },
     )
     resource_id = cursor.fetchone()

--- a/balance_service/enforcement/usage_enforcement.py
+++ b/balance_service/enforcement/usage_enforcement.py
@@ -34,7 +34,7 @@ LeaseEval = collections.namedtuple(
 )
 
 TMP_RESOURCE_ID_PREFIX = "TMP"
-TMP_RESOURCE_ID = "{prefix}/{project_id}/{user_id}/{start_date}"
+TMP_RESOURCE_ID = "{prefix}/{project_id}/{user_id}/{start_date}/{name}"
 
 
 def dt_hours(dt):
@@ -166,6 +166,7 @@ class UsageEnforcer(object):
                     project_id=lease["project_id"],
                     user_id=lease["user_id"],
                     start_date=lease["start_date"],
+                    name=lease["name"],
                 ),
                 resource_type=reservation["resource_type"],
                 start_time=self._convert_to_localtime(


### PR DESCRIPTION
when creating a new charge record, a temporary resource id is given.
a periodic task finds the actual reservation id and replace the
temporary one. However, getting the reservation id based on
project_id, user_id, lease_start_date is not enough, so lease name
condition is added.