### PR TITLE
Add field on user when joining allocation for the first time

### DIFF
--- a/projects/membership.py
+++ b/projects/membership.py
@@ -1,0 +1,26 @@
+from django.contrib.auth import get_user_model
+from util.keycloak_client import KeycloakClient
+
+
+def _update_user_membership(tas_project, user_ref, action=None):
+    if action not in ["add", "delete"]:
+        raise ValueError("Invalid membership action {}".format(action))
+
+    UserModel = get_user_model()
+    try:
+        user = UserModel.objects.get(username=user_ref)
+    except UserModel.DoesNotExist:
+        user = UserModel.objects.get(email=user_ref)
+
+    charge_code = tas_project.chargeCode
+    keycloak_client = KeycloakClient()
+    keycloak_client.update_membership(charge_code, user.username, action)
+    return True
+
+
+def add_user_to_project(tas_project, user_ref):
+    return _update_user_membership(tas_project, user_ref, action="add")
+
+
+def remove_user_from_project(tas_project, user_ref):
+    return _update_user_membership(tas_project, user_ref, action="delete")

--- a/util/project_allocation_mapper.py
+++ b/util/project_allocation_mapper.py
@@ -402,26 +402,6 @@ class ProjectAllocationMapper:
         setattr(alloc, "decision_summary", f"RT ticket created with id: {ticket_id}")
         alloc.save()
 
-    def _update_user_membership(self, tas_project, user_ref, action=None):
-        if action not in ["add", "delete"]:
-            raise ValueError("Invalid membership action {}".format(action))
-
-        UserModel = get_user_model()
-        try:
-            user = UserModel.objects.get(username=user_ref)
-        except UserModel.DoesNotExist:
-            user = UserModel.objects.get(email=user_ref)
-
-        charge_code = self.get_attr(tas_project, "chargeCode")
-        keycloak_client = KeycloakClient()
-        keycloak_client.update_membership(charge_code, user.username, action)
-
-    def add_user_to_project(self, tas_project, user_ref):
-        return self._update_user_membership(tas_project, user_ref, action="add")
-
-    def remove_user_from_project(self, tas_project, user_ref):
-        return self._update_user_membership(tas_project, user_ref, action="delete")
-
     def _parse_field_recursive(self, parent, level=0):
         result = [(parent["id"], "--- " * level + parent["name"])]
         level = level + 1


### PR DESCRIPTION
We'd like to start tracking when users join their first allocation for usage reporting purposes. It helps to know how many users are actually part of an allocation, and what is the delta b/w when they signed up, and when they finally were added to an allocation (if at all.)