### PR TITLE
Store canned approval responses in portal

### DIFF
--- a/allocations/templates/allocations/approval.html
+++ b/allocations/templates/allocations/approval.html
@@ -100,10 +100,21 @@
                     </div>
                 </td>
             </tr>
+            <tr ng-if="data.type == 'approve'">
+                <td><strong>Type:</strong></td>
+                <td>
+                    <select name="allocationApprovalType" id="allocationApprovalType" onchange="getCannedResponsesAllocation(this.value)">
+                        <option value="default">Not Selected</option>
+                        <option value="new">New</option>
+                        <option value="renewal">Renewal</option>
+                        <option value="recharge">Recharge</option>
+                    </select>
+                </td>
+            </tr>
             <tr>
                 <td><strong>Decision Summary</strong>&nbsp;<sup><i style="color: red;font-size:0.5em;" class="fa fa-asterisk"></i></sup></td>
                 <td>
-                    <textarea ng-model="data.allocation.decisionSummary" name="decisionSummary" rows="4" cols="53" ng-required="true"></textarea>
+                    <textarea ng-model="data.allocation.decisionSummary" id="idDecisionSummary" name="decisionSummary" rows="4" cols="53" ng-required="true"></textarea>
                     <div style="color:red" ng-show="modalForm.decisionSummary.$dirty && modalForm.decisionSummary.$invalid">
                         <div ng-show="modalForm.decisionSummary.$error.required">Decision summary is required.</div>
                     </div>

--- a/allocations/templates/allocations/index.html
+++ b/allocations/templates/allocations/index.html
@@ -12,6 +12,7 @@
 {% block extrahead%} {% javascript 'all' %}
 <script src="{% static 'allocations/js/vendor.js' %}"></script>
 <script src="{% static 'allocations/js/main.js' %}"></script>
+<script src="{% static 'scripts/cannedresponses.js' %}"></script>
 {% endblock %}
 
 {% block coltype %}colM{% endblock %}

--- a/chameleon/admin.py
+++ b/chameleon/admin.py
@@ -178,5 +178,15 @@ class PIEligibilityAdmin(ModelAdmin):
             )
         )
 
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form.base_fields["status"].widget.attrs.update(
+            {"onchange": "getCannedResponsesPIEligibility(this.value)"}
+        )
+        return form
+
+    class Media:
+        js = ("scripts/cannedresponses.js",)
+
 
 admin.site.register(PIEligibility, PIEligibilityAdmin)

--- a/static/scripts/cannedresponses.js
+++ b/static/scripts/cannedresponses.js
@@ -1,0 +1,72 @@
+// PI Eligibility
+const piApproval = `Congratulations, your Chameleon PI eligibility request has been approved!
+
+Please, bear in mind that as project PI you will be responsible for ensuring that users gaining access to Chameleon via your project observe security best practices described in:
+https://chameleoncloud.org/blog/2021/06/28/best-practices-making-your-experiments-secure/
+
+Also, please remember that as a condition of use, all users are expected to acknowledge or reference Chameleon in their publications as explained in our FAQ:
+https://chameleoncloud.org/learn/frequently-asked-questions/
+
+We are looking forward to your project request!
+`
+
+function getCannedResponsesPIEligibility(status) {
+    if (status == 'ELIGIBLE') {
+    	document.getElementById('id_review_summary').value=piApproval;
+    } else {
+    	document.getElementById('id_review_summary').value="";
+    }
+}
+
+// Allocations
+const allocationNewApproval = `Congratulations, your Chameleon allocation request has been approved!
+
+Please, bear in mind that as project PI you are responsible for ensuring that users gaining access to Chameleon via your project observe security best practices described in:
+https://chameleoncloud.org/blog/2021/06/28/best-practices-making-your-experiments-secure/
+
+Also, please remember that as a condition of use, all users are expected to acknowledge Chameleon in their publications as explained in our FAQ:
+https://chameleoncloud.org/learn/frequently-asked-questions/
+
+We maintain a list of publications that were enabled by Chameleon. To add your publications, please use the publication dashboard:
+https://chameleoncloud.readthedocs.io/en/latest/user/project.html#manage-publications 
+
+Good luck with your project! If you need any help, please contact us via the Help desk at https://chameleoncloud.org/user/help/!
+`
+
+const allocationRenewalApproval = `Congratulations, your Chameleon Renewal request has been approved to start on <Month> <Day>, <Year> immediately following the end of the current active allocation!
+
+As a reminder, you are responsible for ensuring that users gaining access to Chameleon via your project observe security best practices described in:
+https://chameleoncloud.org/blog/2021/06/28/best-practices-making-your-experiments-secure/
+
+Also, please continue to acknowledge Chameleon in your publications as explained in our FAQ [1] and report your publications via the publication dashboard [2]. 
+
+Good luck with your project!
+
+[1] https://chameleoncloud.org/learn/frequently-asked-questions/
+[2] https://chameleoncloud.readthedocs.io/en/latest/user/project.html#manage-publications
+`
+
+const allocationRechargeApproval = `Congratulations, your Recharge request has been approved, keeping the original end date of the current allocation of <Month> <Day>, <Year>!
+
+As a reminder, you are responsible for ensuring that users gaining access to Chameleon via your project observe security best practices described in:
+https://chameleoncloud.org/blog/2021/06/28/best-practices-making-your-experiments-secure/
+
+Also, please continue to acknowledge Chameleon in your publications as explained in our FAQ [1] and report your publications via the publication dashboard [2].
+
+Good luck with your project!
+
+[1] https://chameleoncloud.org/learn/frequently-asked-questions/
+[2] https://chameleoncloud.readthedocs.io/en/latest/user/project.html#manage-publications
+`
+
+function getCannedResponsesAllocation(type) {
+    if (type == 'new') {
+    	document.getElementById('idDecisionSummary').value=allocationNewApproval;
+    } else if (type == 'renewal') {
+    	document.getElementById('idDecisionSummary').value=allocationRenewalApproval;
+    } else if (type == 'recharge') {
+        document.getElementById('idDecisionSummary').value=allocationRechargeApproval;
+    } else {
+        document.getElementById('idDecisionSummary').value="";
+    }
+}


### PR DESCRIPTION
Currently, all canned pi eligibility and allocation review
responses are stored in a google doc and the responses are
copied and pasted everytime. We would like to have a better
centralized location for the canned responses. Since the
responses are used exclusively with portal, we'll use the
portal to store them. Also, add some javascript functions
for auto-filling based on the selections.