### PR TITLE
Fix trovi content download

### DIFF
--- a/sharing_portal/trovi.py
+++ b/sharing_portal/trovi.py
@@ -1,5 +1,5 @@
 import requests
-from urllib.parse import urljoin, urlparse, urlencode, quote_plus
+from urllib.parse import urljoin, urlparse, urlencode
 from sharing_portal.models import Artifact
 from django.conf import settings
 from django.contrib.auth.models import User

--- a/sharing_portal/trovi.py
+++ b/sharing_portal/trovi.py
@@ -1,5 +1,5 @@
 import requests
-from urllib.parse import urljoin, urlparse, urlencode
+from urllib.parse import urljoin, urlparse, urlencode, quote_plus
 from sharing_portal.models import Artifact
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -331,6 +331,14 @@ def parse_contents_urn(contents_urn):
         "provider": provider,
         "id": contents_id,
     }
+
+
+def get_contents_url_info(token, contents_urn):
+    res = requests.get(
+        url_with_token("/contents/", token, query={"urn": contents_urn})
+    )
+    check_status(res, requests.codes.ok)
+    return res.json()
 
 
 def get_linked_project(artifact):

--- a/sharing_portal/trovi.py
+++ b/sharing_portal/trovi.py
@@ -334,9 +334,7 @@ def parse_contents_urn(contents_urn):
 
 
 def get_contents_url_info(token, contents_urn):
-    res = requests.get(
-        url_with_token("/contents/", token, query={"urn": contents_urn})
-    )
+    res = requests.get(url_with_token("/contents/", token, query={"urn": contents_urn}))
     check_status(res, requests.codes.ok)
     return res.json()
 

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -538,7 +538,9 @@ def launch_url(version, request, token=None, can_edit=False):
     base_url = "{}/hub/import".format(settings.ARTIFACT_SHARING_JUPYTERHUB_URL)
     contents_urn = version["contents"]["urn"]
     contents = trovi.parse_contents_urn(contents_urn)
-    contents_url_info = trovi.get_contents_url_info(token, contents_urn)["access_methods"]
+    contents_url_info = trovi.get_contents_url_info(token, contents_urn)[
+        "access_methods"
+    ]
     http_urls = [access for access in contents_url_info if access["protocol"] == "http"]
     if http_urls:
         contents_url = http_urls[0]["url"]

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -515,6 +515,9 @@ def launch(request, artifact, version_slug=None):
                 )
             )
         )
+
+    trovi_token = request.session.get("trovi_token")
+
     # If no allocation, redirerect to request daypass
     if artifact["reproducibility"]["enable_requests"] and not has_active_allocations(
         request
@@ -523,18 +526,28 @@ def launch(request, artifact, version_slug=None):
             reverse("sharing_portal:request_daypass", args=[artifact["uuid"]]), request
         )
         return redirect(daypass_request_url)
-    trovi.increment_metric_count(
-        artifact["uuid"], version["slug"], token=request.session.get("trovi_token")
+    trovi.increment_metric_count(artifact["uuid"], version["slug"], token=trovi_token)
+    return redirect(
+        launch_url(
+            version, request, token=trovi_token, can_edit=can_edit(request, artifact)
+        )
     )
-    return redirect(launch_url(version, can_edit=can_edit(request, artifact)))
 
 
-def launch_url(version, can_edit=False):
+def launch_url(version, request, token=None, can_edit=False):
     base_url = "{}/hub/import".format(settings.ARTIFACT_SHARING_JUPYTERHUB_URL)
-    contents = trovi.parse_contents_urn(version["contents"]["urn"])
+    contents_urn = version["contents"]["urn"]
+    contents = trovi.parse_contents_urn(contents_urn)
+    contents_url_info = trovi.get_contents_url_info(token, contents_urn)["access_methods"]
+    http_urls = [access for access in contents_url_info if access["protocol"] == "http"]
+    if http_urls:
+        contents_url = http_urls[0]["url"]
+    else:
+        contents_url = contents_url_info[0]["url"]
     query = dict(
         deposition_repo=contents["provider"],
         deposition_id=contents["id"],
+        contents_url=contents_url,
         ownership=("own" if can_edit else "fork"),
     )
     return str(base_url + "?" + urlencode(query))


### PR DESCRIPTION
Portal now fetches the contents download URL from Trovi and passes it on to JupyterHub in the form of a URL parameter
