### PR TITLE
Trovi download archive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,14 @@ services:
     command: ["runserver", "0.0.0.0:${PORTAL_PORT}"]
     depends_on:
       - mysql
+    networks:
+      - chameleon-portal
   referenceapi:
     image: docker.chameleoncloud.org/referenceapi:latest
     ports:
       - "127.0.0.1:8891:8000"
+    networks:
+      - chameleon-portal
   mysql:
     image: mariadb:10
     volumes:
@@ -38,6 +42,8 @@ services:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
+    networks:
+      - chameleon-portal
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     ports:
@@ -47,8 +53,12 @@ services:
       - PMA_PORT=3306
     depends_on:
       - mysql
+    networks:
+      - chameleon-portal
   redis:
     image: redis:alpine
+    networks:
+      - chameleon-portal
   celery:
     image: ${DOCKER_IMAGE_LATEST}
     restart: on-failure
@@ -62,6 +72,8 @@ services:
     depends_on:
       - mysql
       - redis
+    networks:
+      - chameleon-portal
   vue:
     image: node:lts
     command: sh -c 'yarn && yarn serve'
@@ -70,11 +82,19 @@ services:
       - .:/project
     ports:
       - "127.0.0.1:9000:9000"
+    networks:
+      - chameleon-portal
   mail:
     image: mailhog/mailhog:latest
     restart: always
     ports:
-    - "127.0.0.1:8025:8025"
+      - "127.0.0.1:8025:8025"
+    networks:
+      - chameleon-portal
+
+networks:
+  chameleon-portal:
+    external: true
 
 volumes:
   static:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,14 +20,10 @@ services:
     command: ["runserver", "0.0.0.0:${PORTAL_PORT}"]
     depends_on:
       - mysql
-    networks:
-      - chameleon-portal
   referenceapi:
     image: docker.chameleoncloud.org/referenceapi:latest
     ports:
       - "127.0.0.1:8891:8000"
-    networks:
-      - chameleon-portal
   mysql:
     image: mariadb:10
     volumes:
@@ -42,8 +38,6 @@ services:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    networks:
-      - chameleon-portal
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     ports:
@@ -53,12 +47,8 @@ services:
       - PMA_PORT=3306
     depends_on:
       - mysql
-    networks:
-      - chameleon-portal
   redis:
     image: redis:alpine
-    networks:
-      - chameleon-portal
   celery:
     image: ${DOCKER_IMAGE_LATEST}
     restart: on-failure
@@ -72,8 +62,6 @@ services:
     depends_on:
       - mysql
       - redis
-    networks:
-      - chameleon-portal
   vue:
     image: node:lts
     command: sh -c 'yarn && yarn serve'
@@ -82,19 +70,11 @@ services:
       - .:/project
     ports:
       - "127.0.0.1:9000:9000"
-    networks:
-      - chameleon-portal
   mail:
     image: mailhog/mailhog:latest
     restart: always
     ports:
-      - "127.0.0.1:8025:8025"
-    networks:
-      - chameleon-portal
-
-networks:
-  chameleon-portal:
-    external: true
+    - "127.0.0.1:8025:8025"
 
 volumes:
   static:

--- a/sharing_portal/static/sharing_portal/artifacts.css
+++ b/sharing_portal/static/sharing_portal/artifacts.css
@@ -247,3 +247,7 @@
 .artifactVersion__doi {
     font-size: 12px;
 }
+pre code {
+    font-size: 12px;
+    white-space: inherit;
+}

--- a/sharing_portal/templates/sharing_portal/detail.html
+++ b/sharing_portal/templates/sharing_portal/detail.html
@@ -106,8 +106,12 @@
 
     {% for git_method in git_content %}
 <div>
-  <h4><i class="fa fa-code"></i>Checkout with git</h4>
+  <h4><i class="fa fa-code"></i>Download with git</h4>
+    <p class="artifactLaunchButton_details">
+    Clone the git repository for this artifact, and checkout the version's commit
+    </p>
     <pre><code>git clone {{git_method.remote}}
+# cd into the created directory
 git checkout {{git_method.ref}}</code></pre>
 </div>
     {% endfor %}

--- a/sharing_portal/templates/sharing_portal/detail.html
+++ b/sharing_portal/templates/sharing_portal/detail.html
@@ -97,6 +97,21 @@
       </p>
     {% endif %}
 
+    {% if http_content %}
+    <a class="artifactLaunchButton btn btn-primary" href="{{ download_url }}" target="_blank">Download Archive</a>
+    <p class="artifactLaunchButton_details">
+    Download an archive containing the files of this artifact.
+    </p>
+    {% endif %}
+
+    {% for git_method in git_content %}
+<div>
+  <h4><i class="fa fa-code"></i>Checkout with git</h4>
+    <pre><code>git clone {{git_method.remote}}
+git checkout {{git_method.ref}}</code></pre>
+</div>
+    {% endfor %}
+
     <div class="artifactVersions">
       <h4><i class="fa fa-files-o"></i> Versions</h4>
       <ol class="sidebarNav">

--- a/sharing_portal/urls.py
+++ b/sharing_portal/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path("api/git/", views.get_remote_data, name="get_remote_git_data"),
     path("<pk>", views.artifact, name="detail"),
     path("<pk>/launch", views.launch, name="launch"),
+    path("<pk>/download", views.download, name="download"),
     path("<pk>/request", views.request_daypass, name="request_daypass"),
     path("requests/", views.list_daypass_requests, name="list_daypass_requests"),
     path("requests/<int:request_id>", views.review_daypass, name="review_daypass"),
@@ -27,4 +28,9 @@ urlpatterns = [
     ),
     path("<pk>/edit", views.edit_artifact, name="edit"),
     path("<pk>/share", views.share_artifact, name="share"),
+    path(
+        "<pk>/version/<version_slug>/download",
+        views.download,
+        name="download_version",
+    ),
 ]

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -1124,7 +1124,7 @@ def download(request, artifact, version_slug=None):
     for method in access_methods["access_methods"]:
         if method["protocol"] == "http" and method["method"] == "GET":
             return HttpResponseRedirect(method["url"], headers=method["headers"])
-    messages.add_message(request, messages.ERROR, f"Could not download this artifact")
+    messages.add_message(request, messages.ERROR, "Could not download this artifact")
     return HttpResponseRedirect(
         reverse("sharing_portal:detail", args=[artifact["uuid"]])
     )

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -505,12 +505,8 @@ def artifact(request, artifact, version_slug=None):
             request.session.get("trovi_token"), version["contents"]["urn"]
         )["access_methods"]
 
-    git_content = [
-        method for method in access_methods if method["protocol"] == "git"
-    ]
-    http_content = [
-        method for method in access_methods if method["protocol"] == "http"
-    ]
+    git_content = [method for method in access_methods if method["protocol"] == "git"]
+    http_content = [method for method in access_methods if method["protocol"] == "http"]
 
     template = loader.get_template("sharing_portal/detail.html")
 
@@ -1123,11 +1119,11 @@ def create_artifact(request):
 def download(request, artifact, version_slug=None):
     version = _artifact_version(artifact, version_slug)
     access_methods = trovi.get_contents_url_info(
-        request.session.get("trovi_token"), version["contents"]["urn"])
+        request.session.get("trovi_token"), version["contents"]["urn"]
+    )
     for method in access_methods["access_methods"]:
         if method["protocol"] == "http" and method["method"] == "GET":
-            return HttpResponseRedirect(
-                method["url"], headers=method["headers"])
+            return HttpResponseRedirect(method["url"], headers=method["headers"])
     messages.add_message(request, messages.ERROR, f"Could not download this artifact")
     return HttpResponseRedirect(
         reverse("sharing_portal:detail", args=[artifact["uuid"]])

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -1116,7 +1116,6 @@ def create_artifact(request):
 
 @get_artifact
 @with_trovi_token
-@login_required
 def download(request, artifact, version_slug=None):
     version = _artifact_version(artifact, version_slug)
     access_methods = trovi.get_contents_url_info(

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -498,9 +498,13 @@ def artifact(request, artifact, version_slug=None):
     else:
         download_url = reverse("sharing_portal:download", args=[artifact["uuid"]])
     download_url = preserve_sharing_key(download_url, request)
-    access_methods = trovi.get_contents_url_info(
-        request.session.get("trovi_token"), version["contents"]["urn"]
-    )["access_methods"]
+
+    access_methods = []
+    if version:
+        access_methods = trovi.get_contents_url_info(
+            request.session.get("trovi_token"), version["contents"]["urn"]
+        )["access_methods"]
+
     git_content = [
         method for method in access_methods if method["protocol"] == "git"
     ]
@@ -1121,7 +1125,6 @@ def download(request, artifact, version_slug=None):
     access_methods = trovi.get_contents_url_info(
         request.session.get("trovi_token"), version["contents"]["urn"])
     for method in access_methods["access_methods"]:
-        LOG.info(method)
         if method["protocol"] == "http" and method["method"] == "GET":
             return HttpResponseRedirect(
                 method["url"], headers=method["headers"])


### PR DESCRIPTION
This hooks up Trovi's contents endpoint to the side panel on the detail page for artifacts.

Here is an artifact from github, so it has the HTTP archive download, and the git information

![image](https://user-images.githubusercontent.com/9397092/165841940-a24a765a-97e6-45be-92e4-e51fa2e30e36.png)

One issue with redirecting users to the HTTP url directly is that swift URLs downloads a file named just the UUID, with no extension, and the mime type was set to plain text. So my experience was that after downloading in chrome, I clicked on the file, and it opened in a text editor, but it worked fine opening with the archive manager.