### PR TITLE
Add private icon next to a private artifact

### DIFF
--- a/sharing_portal/static/sharing_portal/artifacts.css
+++ b/sharing_portal/static/sharing_portal/artifacts.css
@@ -72,6 +72,7 @@
 
 .cardItem__title {
     margin: 0 0 1rem;
+    display: flex;
 }
 
 .cardItem__body {
@@ -246,4 +247,16 @@
 
 .artifactVersion__doi {
     font-size: 12px;
+}
+
+.cardTitleTitle {
+    flex: 1;
+}
+.cardTitlePrivate {
+    flex: 1;
+    text-align: right;
+}
+.artifactDetailPrivate {
+    font-size: 32px;
+    vertical-align: middle;
 }

--- a/sharing_portal/static/sharing_portal/tooltip.js
+++ b/sharing_portal/static/sharing_portal/tooltip.js
@@ -1,0 +1,7 @@
+if (document.readyState !== 'loading') {
+    $('[data-toggle=tooltip]').tooltip();
+} else {
+    document.addEventListener('DOMContentLoaded', function () {
+        $('[data-toggle=tooltip]').tooltip();
+    });
+}

--- a/sharing_portal/templates/sharing_portal/detail.html
+++ b/sharing_portal/templates/sharing_portal/detail.html
@@ -20,8 +20,13 @@
   <div class="layoutGrid__main">
     <div class="artifactDetail">
       <header class="artifactDetail__heading">
-        <h2 class="artifactTitle">{{ artifact.title }}</h2>
+        <h2 class="artifactTitle">
+          {{ artifact.title }}
+        </h2>
         <div class="artifactActions">
+          {% if artifact.visibility == "private" and not doi_info.doi %}
+            <i class="fa fa-eye-slash artifactDetailPrivate"></i>
+          {% endif %}
           {% if editable %}
           <a class="btn btn-default" href="{% url 'sharing_portal:share' artifact.uuid %}">
             <i class="fa fa-share"></i> Share

--- a/sharing_portal/templates/sharing_portal/detail.html
+++ b/sharing_portal/templates/sharing_portal/detail.html
@@ -7,6 +7,11 @@
 <link rel="stylesheet" type="text/css" href="{% static 'sharing_portal/artifacts.css' %}">
 {% endblock %}
 
+{% block scripts %}
+{{ block.super }}
+<script src="{% static 'sharing_portal/tooltip.js' %}"></script>
+{% endblock %}
+
 {% block content %}
 {# Experiments / [current_exp_title] subheader #}
 <ol class="breadcrumb">
@@ -25,7 +30,7 @@
         </h2>
         <div class="artifactActions">
           {% if artifact.visibility == "private" and not doi_info.doi %}
-            <i class="fa fa-eye-slash artifactDetailPrivate"></i>
+            <i class="fa fa-eye-slash artifactDetailPrivate" data-toggle="tooltip" data-placement="top" title="This artifact is only visible for those chosen by the author"></i>
           {% endif %}
           {% if editable %}
           <a class="btn btn-default" href="{% url 'sharing_portal:share' artifact.uuid %}">

--- a/sharing_portal/templates/sharing_portal/index.html
+++ b/sharing_portal/templates/sharing_portal/index.html
@@ -11,6 +11,7 @@
 {% block scripts %}
 {{ block.super }}
 <script src="{% static 'sharing_portal/index.js' %}"></script>
+<script src="{% static 'sharing_portal/tooltip.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -25,7 +26,7 @@
           <span class="cardTitleTitle">{{ artifact.title }}</span>
           <span class="cardTitlePrivate">
           {% if artifact.is_private %}
-            <i class="fa fa-eye-slash"></i>
+            <i class="fa fa-eye-slash" data-toggle="tooltip" data-placement="top" title="This artifact is only visible for those chosen by the author"></i>
           {% endif %}
           </span>
         </h5>

--- a/sharing_portal/templates/sharing_portal/index.html
+++ b/sharing_portal/templates/sharing_portal/index.html
@@ -21,7 +21,14 @@
     {% for artifact in artifacts %}
     <div class="cardItem" data-search="{{ artifact.search_terms|join:' ' }}">
       <a class="blockLink" href="{% url 'sharing_portal:detail' artifact.uuid %}">
-        <h5 class="cardItem__title">{{ artifact.title }}</h5>
+        <h5 class="cardItem__title">
+          <span class="cardTitleTitle">{{ artifact.title }}</span>
+          <span class="cardTitlePrivate">
+          {% if artifact.is_private %}
+            <i class="fa fa-eye-slash"></i>
+          {% endif %}
+          </span>
+        </h5>
         <div class="cardItem__body">
           {% if artifact.short_description %}
           <p class="artifactGridItem__description">

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -151,6 +151,9 @@ def _compute_artifact_fields(artifact):
     artifact["is_chameleon_supported"] = any(
         label == "chameleon" for label in artifact["tags"]
     )
+    artifact["is_private"] = (
+        artifact["visibility"] == "private" and not _parse_doi(artifact)
+    )
     return artifact
 
 

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -151,8 +151,8 @@ def _compute_artifact_fields(artifact):
     artifact["is_chameleon_supported"] = any(
         label == "chameleon" for label in artifact["tags"]
     )
-    artifact["is_private"] = (
-        artifact["visibility"] == "private" and not _parse_doi(artifact)
+    artifact["is_private"] = artifact["visibility"] == "private" and not _parse_doi(
+        artifact
     )
     return artifact
 


### PR DESCRIPTION
This shows an icon next to an artifact title when the artifact is private. The only other place this information is displayed is inside the sharing settings.

List view:
<img width="776" alt="image" src="https://user-images.githubusercontent.com/9397092/166476516-b6defc22-fcb3-4563-9858-f12b6f340119.png">


Detail view:
<img width="780" alt="image" src="https://user-images.githubusercontent.com/9397092/166476389-f012dbd7-e695-4448-a30b-ead2ee5ee652.png">
