### PR TITLE
Add check for allocation expiration in enforcement

### DIFF
--- a/balance_service/enforcement/exceptions.py
+++ b/balance_service/enforcement/exceptions.py
@@ -38,3 +38,9 @@ class EnforcementException(Exception):
 class BillingError(EnforcementException):
     msg_fmt = "Not authorized"
     code = 403
+
+
+class LeasePastExpirationError(EnforcementException):
+    msg_fmt = "Not authorized"
+    code = 403
+    message = "Cannot create reservation beyond allocation expiration date"


### PR DESCRIPTION
This prevents creating a lease that extends beyond someone's allocation.