### PR TITLE
Add way to bulk add users on project page

### DIFF
--- a/projects/forms.py
+++ b/projects/forms.py
@@ -269,3 +269,9 @@ class AddBibtexPublicationForm(forms.Form):
             return False
 
         return True
+
+class ProjectAddBulkUserForm(forms.Form):
+    username_csv = forms.CharField(
+        label="Usernames or emails",
+        widget=forms.Textarea(attrs={"placeholder": "Usernames seperated by commas"}),
+    )

--- a/projects/static/projects/js/bulk_invite.js
+++ b/projects/static/projects/js/bulk_invite.js
@@ -1,0 +1,8 @@
+'use strict';
+(function( window, $, undefined ) {
+  $('button[name="add_bulk_users_popup"]').on('click', function(e) {
+    e.preventDefault()
+    var $popup = $("#bulk_invite_popup");
+    $popup.modal("show");
+  });
+})( this, $ );

--- a/projects/templates/projects/bulk_invite_modal.html
+++ b/projects/templates/projects/bulk_invite_modal.html
@@ -1,0 +1,25 @@
+{% load bootstrap3 %}
+<div id="bulk_invite_popup" class="modal fade" role="dialog" style="padding-top:5%;">
+  <div class="modal-dialog" style="width: 90%;">
+    <div class="modal-content">
+      <form class="form" role="form" method="post">
+        <div class="modal-body">
+          <p>
+          Please enter usernames below, seperated by commas. For example
+          <pre>user1,user2@uchicago.edu,...</pre>
+          </p>
+            {% csrf_token %}
+            <div>
+            {% bootstrap_field bulk_user_form.username_csv layout='block' %}
+            </div>
+        </div>
+        <div class="modal-footer">
+          <div class="form-group">
+            <button type="button" class="btn btn-info" data-dismiss="modal">Close</button>
+            <button type="submit" class="btn btn-success" name="add_bulk_users">Add multiple users</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/projects/templates/projects/view_project.html
+++ b/projects/templates/projects/view_project.html
@@ -146,8 +146,10 @@
   {% bootstrap_form form %}
   <div class="form-group">
     <button type="submit" class="btn btn-default" name="add_user">Add user</button>
+    <button class="btn btn-default" name="add_bulk_users_popup">Add multiple users</button>
   </div>
 </form>
+{% include "projects/bulk_invite_modal.html" %}
 {% endif %}
 
 <br>
@@ -256,4 +258,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="{% static 'projects/js/allocations.js' %}" type="text/javascript"></script>
 <script src="{% static 'projects/js/members.js' %}" type="text/javascript"></script>
+<script src="{% static 'projects/js/bulk_invite.js' %}" type="text/javascript"></script>
 {% endblock %}


### PR DESCRIPTION
This adds a way to add multiple users at once to a project via a comma separated list.

A new button is next to the add user button.

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/9397092/168892043-e920fe36-e45d-4048-9df0-7d7c131a425d.png">

When clicked, it opens a modal with a textfield.

<img width="1351" alt="image" src="https://user-images.githubusercontent.com/9397092/168892236-ca614aa3-358f-48ba-9ef1-73eac21ad2ba.png">

Message summaries appear after form submission. All error messages are shown, which give detail of what users could not be added:

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/9397092/168892336-a00e2b95-42d1-41ad-a2e6-1a44aa9ddcbf.png">

Or if there are no issues, that is displayed as well:
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/9397092/168892478-384b1549-6746-473d-bfe2-4165635dea68.png">

When adding a single user, nothing different is changed. The biggest concern with this change is that it could time out if too many emails are being sent, if users come across this we will need to defer sending mail to a celery task.