### PR TITLE
Clean up hardware browser UI

### DIFF
--- a/g5k_discovery/templates/g5k_discovery/discovery.html
+++ b/g5k_discovery/templates/g5k_discovery/discovery.html
@@ -4,33 +4,37 @@
 {% block title %}Chameleon Resource Browser{% endblock %}
 
 {% block content %}
-<div>
-    <h1>Availability</h1>
-    <div class="row">
-        <div class="col col-sm-2">
-            <a target="blank" href="https://chi.tacc.chameleoncloud.org/project/leases/calendar/host/"
-                class="btn btn-lg btn-primary btn-filter btn-block">CHI@TACC</a>
-        </div>
-        <div class="col col-sm-2">
-            <a target="blank" href="https://chi.uc.chameleoncloud.org/project/leases/calendar/host/"
-                class="btn btn-lg btn-primary btn-filter btn-block">CHI@UC</a>
-        </div>
-        <div class="col col-sm-2">
-            <!-- NU is Running an older deployment, revert this when updated. -->
-            <a target="_self" href="https://sl-ciab.northwestern.edu/project/leases/calendar/"
-                class="btn btn-lg btn-primary btn-filter btn-block">CHI@NU</a>
-        </div>
-        <div class="col col-sm-2">
-            <a target="_self" href="https://chi.hpc.ucar.edu/project/leases/calendar/host/"
-                class="btn btn-lg btn-primary btn-filter btn-block">CHI@NCAR</a>
-        </div>
-        <div class="col col-sm-2">
-            <a target="_self" href="https://chi.evl.uic.edu/project/leases/calendar/host/"
-                class="btn btn-lg btn-primary btn-filter btn-block">CHI@EVL</a>
-        </div>
+<h1>Hardware Discovery</h1>
+<div class="row">
+    <div class="col col-md-8">
+        <p>Check the availability calendar at each site for details on when
+        resources are available for reservation.</p>
     </div>
 </div>
-<h1 class="title">Chameleon Resource Browser</h1>
+<div class="row">
+    <div class="col col-sm-2">
+        <a target="blank" href="https://chi.tacc.chameleoncloud.org/project/leases/calendar/host/"
+            class="btn btn-lg btn-block btn-default">CHI@TACC <i class="fa fa-external-link"></i></a>
+    </div>
+    <div class="col col-sm-2">
+        <a target="blank" href="https://chi.uc.chameleoncloud.org/project/leases/calendar/host/"
+            class="btn btn-lg btn-block btn-default">CHI@UC <i class="fa fa-external-link"></i></a>
+    </div>
+    <div class="col col-sm-2">
+        <!-- NU is Running an older deployment, revert this when updated. -->
+        <a target="_self" href="https://sl-ciab.northwestern.edu/project/leases/calendar/"
+            class="btn btn-lg btn-block btn-default">CHI@NU <i class="fa fa-external-link"></i></a>
+    </div>
+    <div class="col col-sm-2">
+        <a target="_self" href="https://chi.hpc.ucar.edu/project/leases/calendar/host/"
+            class="btn btn-lg btn-block btn-default">CHI@NCAR <i class="fa fa-external-link"></i></a>
+    </div>
+    <div class="col col-sm-2">
+        <a target="_self" href="https://chi.evl.uic.edu/project/leases/calendar/host/"
+            class="btn btn-lg btn-block btn-default">CHI@EVL <i class="fa fa-external-link"></i></a>
+    </div>
+</div>
+<h2>Resource Browser</h2>
 {% csrf_token %}
 <div id="app"></div>
 {% endblock content %}

--- a/g5k_discovery/templates/g5k_discovery/node_details.html
+++ b/g5k_discovery/templates/g5k_discovery/node_details.html
@@ -1,7 +1,7 @@
 {% extends 'layout/default.html' %} {% load sekizai_tags static %} {% block title %}Chameleon Resource Browser{% endblock %} {% block styles %}
 <link rel="stylesheet" type="text/css" href="{% static 'g5k_discovery/css/main.css' %}"> {% endblock %} {% block content %}
 
-<h2>Details for node {{ node.uid }}</h2>
+<h2>{{ node.uid }} {% if node.node_name %}({{ node.node_name }}){% endif %}</h2>
 <div ng-app="discoveryApp" class="discovery-app" ng-controller="NodeController" ng-init="initLink('{{resource}}');">
         <section>
             <div class="row">

--- a/g5k_discovery/vue/HardwareCatalogueFilters.vue
+++ b/g5k_discovery/vue/HardwareCatalogueFilters.vue
@@ -240,37 +240,6 @@ export default {
     allNodes: Array,
   },
   data() {
-    // const coarseFilters = [
-    //   createFilter("Cascade Lake", ".{.nodeType ^= 'compute_cascadelake'}", {
-    //     constraint: ["==", "$node_type", "compute_cascadelake"],
-    //   }),
-    //   createFilter("Skylake", ".{.nodeType === 'compute_skylake'}", {
-    //     constraint: ["==", "$node_type", "compute_skylake"],
-    //   }),
-    //   createFilter("Haswell", ".{.nodeType === 'compute_haswell'}", {
-    //     constraint: ["==", "$node_type", "compute_haswell"],
-    //   }),
-    //   createFilter("Infiniband", ".{.nodeType === 'compute_haswell_ib'}", {
-    //     constraint: ["==", "$node_type", "compute_haswell_ib"],
-    //   }),
-    //   createFilter("GPU", ".{.nodeType ^= 'gpu_'}", {
-    //     constraint: [">=", "$gpu.gpu_count", 1],
-    //   }),
-    //   createFilter("Storage", ".{.nodeType === 'storage'}", {
-    //     constraint: ["==", "$node_type", "storage"],
-    //   }),
-    //   createFilter(
-    //     "Storage Hierarchy",
-    //     ".{.nodeType === 'storage_hierarchy'}",
-    //     {
-    //       constraint: ["==", "$node_type", "storage_hierarchy"],
-    //     }
-    //   ),
-    //   createFilter("FPGA", ".{.nodeType === 'fpga'}", {
-    //     constraint: ["==", "$node_type", "fpga"],
-    //   }),
-    // ];
-
     // Needs to be an arrow-function because we need 'this' reference.
     const processCapabilities = (capabilities) => {
       return Object.fromEntries(

--- a/g5k_discovery/vue/HardwareCatalogueFilters.vue
+++ b/g5k_discovery/vue/HardwareCatalogueFilters.vue
@@ -240,36 +240,36 @@ export default {
     allNodes: Array,
   },
   data() {
-    const coarseFilters = [
-      createFilter("Cascade Lake", ".{.nodeType ^= 'compute_cascadelake'}", {
-        constraint: ["==", "$node_type", "compute_cascadelake"],
-      }),
-      createFilter("Skylake", ".{.nodeType === 'compute_skylake'}", {
-        constraint: ["==", "$node_type", "compute_skylake"],
-      }),
-      createFilter("Haswell", ".{.nodeType === 'compute_haswell'}", {
-        constraint: ["==", "$node_type", "compute_haswell"],
-      }),
-      createFilter("Infiniband", ".{.nodeType === 'compute_haswell_ib'}", {
-        constraint: ["==", "$node_type", "compute_haswell_ib"],
-      }),
-      createFilter("GPU", ".{.nodeType ^= 'gpu_'}", {
-        constraint: [">=", "$gpu.gpu_count", 1],
-      }),
-      createFilter("Storage", ".{.nodeType === 'storage'}", {
-        constraint: ["==", "$node_type", "storage"],
-      }),
-      createFilter(
-        "Storage Hierarchy",
-        ".{.nodeType === 'storage_hierarchy'}",
-        {
-          constraint: ["==", "$node_type", "storage_hierarchy"],
-        }
-      ),
-      createFilter("FPGA", ".{.nodeType === 'fpga'}", {
-        constraint: ["==", "$node_type", "fpga"],
-      }),
-    ];
+    // const coarseFilters = [
+    //   createFilter("Cascade Lake", ".{.nodeType ^= 'compute_cascadelake'}", {
+    //     constraint: ["==", "$node_type", "compute_cascadelake"],
+    //   }),
+    //   createFilter("Skylake", ".{.nodeType === 'compute_skylake'}", {
+    //     constraint: ["==", "$node_type", "compute_skylake"],
+    //   }),
+    //   createFilter("Haswell", ".{.nodeType === 'compute_haswell'}", {
+    //     constraint: ["==", "$node_type", "compute_haswell"],
+    //   }),
+    //   createFilter("Infiniband", ".{.nodeType === 'compute_haswell_ib'}", {
+    //     constraint: ["==", "$node_type", "compute_haswell_ib"],
+    //   }),
+    //   createFilter("GPU", ".{.nodeType ^= 'gpu_'}", {
+    //     constraint: [">=", "$gpu.gpu_count", 1],
+    //   }),
+    //   createFilter("Storage", ".{.nodeType === 'storage'}", {
+    //     constraint: ["==", "$node_type", "storage"],
+    //   }),
+    //   createFilter(
+    //     "Storage Hierarchy",
+    //     ".{.nodeType === 'storage_hierarchy'}",
+    //     {
+    //       constraint: ["==", "$node_type", "storage_hierarchy"],
+    //     }
+    //   ),
+    //   createFilter("FPGA", ".{.nodeType === 'fpga'}", {
+    //     constraint: ["==", "$node_type", "fpga"],
+    //   }),
+    // ];
 
     // Needs to be an arrow-function because we need 'this' reference.
     const processCapabilities = (capabilities) => {
@@ -284,6 +284,7 @@ export default {
       );
     };
 
+    const coarseFilters = createCapabilityFilters(".nodeType", this.allNodes);
     const simpleCapabilityFilters = processCapabilities(simpleCapabilities);
     const advancedCapabilityFilters = Object.fromEntries(
       Object.entries(advancedCapabilities).map(

--- a/g5k_discovery/vue/HardwareDetails.vue
+++ b/g5k_discovery/vue/HardwareDetails.vue
@@ -12,6 +12,7 @@
         "
         >{{ hardware.nodeName || hardware.uid }}</a
       >
+      <span class="label label-default node-type">{{ hardware.nodeType }}</span>
     </h4>
     <section>
       <div class="row">
@@ -43,6 +44,10 @@
 .hardware-details {
   margin: 1rem 0;
   padding: 1rem 0;
+}
+
+.node-type {
+  margin-left: 1em;
 }
 </style>
 

--- a/g5k_discovery/vue/InfiniteScroller.vue
+++ b/g5k_discovery/vue/InfiniteScroller.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-for="(item, idx) in visibleItems" :key="visibleItems.length + idx">
+    <div v-for="(item, idx) in visibleItems" :key="idx + item.uid">
       <slot v-bind:item="item"></slot>
     </div>
     <div v-if="numRemaining">


### PR DESCRIPTION
1. Replace human-friendly node type “summaries” with the actual node types in the big green box. Users are already confused about this enough, I think we can just stick to node type as a general filter mechanism.
2. Make the top line of buttons NOT green so they’re not semantically linked w/ the below buttons, which act as filters (the top row are all external links!)
3. Add the node type as a label in the details view so you can easily see which nodes are of which type.
4. Tightened up the headings a bit and renamed to match menu nav terminology.