### PR TITLE
Add our domains to image csp

### DIFF
--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -867,6 +867,8 @@ CSP_FRAME_SRC = [
 ]
 CSP_IMG_SRC = [
     "'self'",
+    "https://chameleoncloud.org",
+    "https://www.chameleoncloud.org",
     "https://www.google-analytics.com",
     "https://*.googleusercontent.com",
 ]


### PR DESCRIPTION
Our images are uploaded either while on chameleoncloud.org
or www.chameleoncloud.org. Since the absolute URL is used in the CMS,
the images won't load when using the site via the other domain, since
the CSP only contained 'self' (along with some google domains). This
fix adds both domains, meaning that it should always be able to load the
images.