### PR TITLE
Fix passing of ownership/artifact meta to jupyter

### DIFF
--- a/djangoRT/forms.py
+++ b/djangoRT/forms.py
@@ -52,20 +52,32 @@ class BaseTicketForm(forms.Form):
     )
     email = forms.EmailField(widget=forms.EmailInput(), label="Email", required=True)
     project_id = forms.CharField(
-        widget=forms.TextInput(), label="Project ID", max_length=100, required=False,
-        help_text="Which project are you using,  if applicable (e.g. CHI-123456)."
+        widget=forms.TextInput(),
+        label="Project ID",
+        max_length=100,
+        required=False,
+        help_text="Which project are you using,  if applicable (e.g. CHI-123456).",
     )
     site = forms.CharField(
-        widget=forms.TextInput(), label="Site", max_length=100, required=False,
-        help_text="Which site you are using, if applicable (e.g. CHI@TACC)."
+        widget=forms.TextInput(),
+        label="Site",
+        max_length=100,
+        required=False,
+        help_text="Which site you are using, if applicable (e.g. CHI@TACC).",
     )
     lease_id = forms.CharField(
-        widget=forms.TextInput(), label="Lease ID", max_length=100, required=False,
-        help_text="Your lease ID, if applicable (e.g. 123e4567-e89b-12d3-a456-426614174000)"
+        widget=forms.TextInput(),
+        label="Lease ID",
+        max_length=100,
+        required=False,
+        help_text="Your lease ID, if applicable (e.g. 123e4567-e89b-12d3-a456-426614174000)",
     )
     instance_id = forms.CharField(
-        widget=forms.TextInput(), label="Instance ID", max_length=100, required=False,
-        help_text="Your instance ID, if applicable (e.g. 123e4567-e89b-12d3-a456-426614174000)"
+        widget=forms.TextInput(),
+        label="Instance ID",
+        max_length=100,
+        required=False,
+        help_text="Your instance ID, if applicable (e.g. 123e4567-e89b-12d3-a456-426614174000)",
     )
     subject = forms.CharField(
         widget=forms.TextInput(), label="Subject", max_length=100, required=True

--- a/djangoRT/views.py
+++ b/djangoRT/views.py
@@ -25,92 +25,92 @@ logger = logging.getLogger("default")
 
 QUESTION_GROUPS = [
     {
-      "label": "Reservations",
-      "desc": "When submitting a ticket regarding reservations, please include the lease ID if possible.",
-      "questions": [
-        {
-          "label": "Lease is missing resources",
-          "desc": '''If your lease is missing resources, then one of its nodes was
+        "label": "Reservations",
+        "desc": "When submitting a ticket regarding reservations, please include the lease ID if possible.",
+        "questions": [
+            {
+                "label": "Lease is missing resources",
+                "desc": """If your lease is missing resources, then one of its nodes was
             detected as unhealthy. There was no replacement that could be
             found at the time. If you check the
             <a href="https://chameleoncloud.org/hardware/">availability calendar</a>
             for the site you are using, you may be able to create a second
-            lease to make up for the missing resources.''',
-        },
-        {
-          "label": "A node isn't working in my lease",
-          "desc": '''If a node in your lease is causing issues, you can try to create
+            lease to make up for the missing resources.""",
+            },
+            {
+                "label": "A node isn't working in my lease",
+                "desc": """If a node in your lease is causing issues, you can try to create
             a second lease to make up the troublesome one. Please submit a
             ticket including the problematic lease ID, and if known, the
-            ID of the node so that we can investigate the node.''',
-        },
-        {
-          "label": "Creating a lease fails",
-          "desc": '''If your lease fails with a message saying "Not enough resources..."
+            ID of the node so that we can investigate the node.""",
+            },
+            {
+                "label": "Creating a lease fails",
+                "desc": """If your lease fails with a message saying "Not enough resources..."
                 then either the resources matching your query are reserved (see the
                 <a href="https://chameleoncloud.org/hardware/">availability calendar</a>
                 to check) or your query doesn't match any resources, in which case
-                double check that the resource type or ID you specify is correct.'''
-        },
-        {
-          "label": "I can't renew my lease",
-          "desc": '''Renewing a lease requires that it's resources are not reserved
+                double check that the resource type or ID you specify is correct.""",
+            },
+            {
+                "label": "I can't renew my lease",
+                "desc": """Renewing a lease requires that it's resources are not reserved
                 by others during the period you are renewing for. See the
                 <a href="https://chameleoncloud.org/hardware/">availability calendar</a>
                 to make sure your reserved resources are free. If they are not,
                 you can create a
                 <a href="https://chameleoncloud.readthedocs.io/en/latest/technical/images.html#the-cc-snapshot-utility">snapshot</a>
-                of your image, and then relaunch it on a new lease.'''
-        },
-      ],
+                of your image, and then relaunch it on a new lease.""",
+            },
+        ],
     },
     {
-      "label": "Instance Creation/Connectivity/Usage",
-      "desc": "When submitting a ticket regarding instances, please include the instance ID if possible.",
-      "questions": [
-        {
-          "label": "One of my nodes won't launch",
-          "desc": '''If you launch multiple nodes at the same time, sometimes the
+        "label": "Instance Creation/Connectivity/Usage",
+        "desc": "When submitting a ticket regarding instances, please include the instance ID if possible.",
+        "questions": [
+            {
+                "label": "One of my nodes won't launch",
+                "desc": """If you launch multiple nodes at the same time, sometimes the
             service may be overwhelmed. Try launching again, one node at a
-            time for any failed nodes.''',
-        },
-        {
-          "label": "The BIOS settings on my instance are incorrect",
-          "desc": '''If node functionality is not working as expected due to a
-            BIOS setting, please submit a ticket letting us know.'''
-        }
-      ]
+            time for any failed nodes.""",
+            },
+            {
+                "label": "The BIOS settings on my instance are incorrect",
+                "desc": """If node functionality is not working as expected due to a
+            BIOS setting, please submit a ticket letting us know.""",
+            },
+        ],
     },
     {
-      "label": "Jupyter/Trovi",
-      "questions": [
-        {
-          "label": "Error 'The request you have made requires authentication'",
-          "desc": '''This error can appear if you are using the wrong project
+        "label": "Jupyter/Trovi",
+        "questions": [
+            {
+                "label": "Error 'The request you have made requires authentication'",
+                "desc": """This error can appear if you are using the wrong project
             name. Make sure to update the project ID in the file you are
-            running.'''
-        },
-        {
-          "label": "An artifact is not working as expected",
-          "desc": '''If an artifact isn't working, there may be a few causes. If
+            running.""",
+            },
+            {
+                "label": "An artifact is not working as expected",
+                "desc": """If an artifact isn't working, there may be a few causes. If
             the error message you are seeing is about "not enough resources",
             then the node type configured in the notebook. Check the
             <a href="https://chameleoncloud.org/hardware/">availability calendar</a>
             to see what nodes are free. For other issues, there may be an issue
             with the notebook's itself. In this case, please contact the author
-            with specific questions.''',
-        }
-      ],
+            with specific questions.""",
+            },
+        ],
     },
     {
-      "label": "Account Management",
-      "questions": [
-        {
-          "label": "Linking/Migrating accounts",
-          "desc": '''For help migrating or linking accounts, please see our
-            <a href="https://chameleoncloud.readthedocs.io/en/latest/user/federation/federation_migration.html">migration guide</a>.'''
-        }
-      ],
+        "label": "Account Management",
+        "questions": [
+            {
+                "label": "Linking/Migrating accounts",
+                "desc": """For help migrating or linking accounts, please see our
+            <a href="https://chameleoncloud.readthedocs.io/en/latest/user/federation/federation_migration.html">migration guide</a>.""",
+            }
+        ],
     },
 ]
 
@@ -274,10 +274,14 @@ def ticketcreate(request):
             }
         )
 
-    return render(request, "djangoRT/ticketCreate.html", {
-        "form": form,
-        "question_groups": QUESTION_GROUPS,
-    })
+    return render(
+        request,
+        "djangoRT/ticketCreate.html",
+        {
+            "form": form,
+            "question_groups": QUESTION_GROUPS,
+        },
+    )
 
 
 def ticketcreateguest(request):

--- a/sharing_portal/models.py
+++ b/sharing_portal/models.py
@@ -228,16 +228,6 @@ class ArtifactVersion(models.Model):
         else:
             return None
 
-    def launch_url(self, can_edit=False):
-        base_url = "{}/hub/import".format(settings.ARTIFACT_SHARING_JUPYTERHUB_URL)
-        query = dict(
-            deposition_repo=self.deposition_repo,
-            deposition_id=self.deposition_id,
-            id=self.artifact.id,
-            ownership=("own" if can_edit else "fork"),
-        )
-        return str(base_url + "?" + urlencode(query))
-
     def __str__(self):
         return f"{self.artifact.title} ({self.created_at})"
 

--- a/sharing_portal/tasks.py
+++ b/sharing_portal/tasks.py
@@ -76,14 +76,14 @@ def publish_to_zenodo(artifact_version_id, zenodo_access_token=None):
     artifact_version.save()
 
 
-def _temp_url(deposition_id):
+def _temp_url(contents_id):
     endpoint = os.environ["ARTIFACT_SHARING_SWIFT_ENDPOINT"]
     origin = endpoint[: endpoint.index("/v1/")]
     path = "/".join(
         [
             endpoint[endpoint.index("/v1/") :],
             os.environ["ARTIFACT_SHARING_SWIFT_CONTAINER"],
-            deposition_id,
+            contents_id,
         ]
     )
     key = os.environ["ARTIFACT_SHARING_SWIFT_TEMP_URL_KEY"]

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -607,8 +607,8 @@ def launch_url(version, request, token=None, can_edit=False):
         contents_url = ""
         proto = ""
     query = dict(
-        deposition_repo=contents["provider"],
-        deposition_id=contents["id"],
+        contents_repo=contents["provider"],
+        contents_id=contents["id"],
         contents_url=contents_url,
         contents_proto=proto,
         ownership=("own" if can_edit else "fork"),

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -147,7 +147,7 @@ def _render_list(request, artifacts):
 def _compute_artifact_fields(artifact):
     terms = artifact["title"].lower().split()
     terms.extend([f"tag:{label.lower()}" for label in artifact["tags"]])
-    for name in [author['full_name'] for author in artifact["authors"]]:
+    for name in [author["full_name"] for author in artifact["authors"]]:
         terms.extend(name.lower().split(" "))
     artifact["search_terms"] = terms
     artifact["is_chameleon_supported"] = any(


### PR DESCRIPTION
Currently the workflow of creating a new version from an artifact
is busted if you are launching it for the first time and you own it.
Probably this only affects artifacts made before the migration, as
those are the ones that effectively had their local DB state cleared.
Though, this also would affect users who try to launch their own
artifact at the latest version, after publishing that version (because
it creates a new server, w/ a new notebook directory from scratch.)

Requires chameleoncloud/jupyterlab-chameleon#19 and
chameleoncloud/jupyterhub-chameleon#6