### PR TITLE
Change the webinar link on user dashboard to link to the same page as the CMS menu

### DIFF
--- a/chameleon_cms_integrations/cms_menus.py
+++ b/chameleon_cms_integrations/cms_menus.py
@@ -100,7 +100,10 @@ class UserMenu(CMSAttachMenu):
 
         menu_id += 1
         n = NavigationNode(
-            _("Webinars"), reverse("webinar_registration:index"), menu_id, dashboard_id
+            _("Webinars"),
+            "https://www.chameleoncloud.org/learn/webinars/",
+            menu_id,
+            dashboard_id
         )
         nodes.append(n)
 


### PR DESCRIPTION
I was unable to find a reverse link for the webinar page from the CMS menu. It looks like the page previously linked-to was used for webinar registration, and we use models from this app on the dashboard. Is this something we use at all anymore? Should it be purged from the user portal?
