### PR TITLE
Trovi error messages are not very helpful in Portal

### DIFF
--- a/sharing_portal/trovi.py
+++ b/sharing_portal/trovi.py
@@ -25,8 +25,10 @@ class TroviException(Exception):
 
     @property
     def message(self):
-        return (f"{self.method} {self.path} {self.actual_code} returned, "
-                f"expected {self.expected_code}: {self.detail}")
+        return (
+            f"{self.method} {self.path} {self.actual_code} returned, "
+            f"expected {self.expected_code}: {self.detail}"
+        )
 
     @property
     def code(self):

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -86,6 +86,7 @@ def with_trovi_token(view_func):
 
     return _wrapped_view
 
+
 def handle_trovi_errors(view_func):
     def _wrapped_view(request, *args, **kwargs):
         try:
@@ -93,6 +94,7 @@ def handle_trovi_errors(view_func):
         except trovi.TroviException as e:
             LOG.exception(e)
             messages.error(request, e.detail)
+
     return _wrapped_view
 
 
@@ -403,7 +405,6 @@ def share_artifact(request, artifact):
                     return HttpResponseRedirect(
                         reverse("sharing_portal:share", args=[artifact["uuid"]])
                     )
-
 
             if patches:
                 trovi.patch_artifact(


### PR DESCRIPTION
Any unhandled Trovi exceptions in Portal would previously give an opaque error message to the user, which would not inform them of what actually went wrong. Now, any unhandled Trovi errors will have the API error message forwarded to the user.

`TroviException` is been modified to hold on to more error context.

The `handle_trovi_errors` decorator is implemented to wrap views with a `TroviException` handler, so that any `TroviExceptions` which would otherwise be unhandled are caught, and the API error message is reported to the user. This does not impede any explicit error handling within view functions.

There was some error reporting inside a generator expression that was never actually executed, so errors were never displayed.

The `PATCH` request generated by the sharing form also displayed an opaque error message, so handling has been referred to the decorator. This is the easiest way to handle patch errors, because it will explicitly display the fields which are incorrect.

