### PR TITLE
fix balance service check_alloc_expiration_date

### DIFF
--- a/balance_service/utils/su_calculators.py
+++ b/balance_service/utils/su_calculators.py
@@ -28,6 +28,15 @@ def get_active_allocation(project):
     return next(project.allocations.filter(status="active").iterator(), None)
 
 
+def get_consecutive_approved_allocation(project, alloc):
+    approved_allocs = project.allocations.filter(
+        status="approved",
+        start_date__lte=alloc.expiration_date,
+        expiration_date__gte=alloc.expiration_date,
+    )
+    return next(approved_allocs.iterator(), None)
+
+
 def project_balances(project_ids) -> "list[dict]":
     """Return a list of balance information for each input project.
 

--- a/chameleon_cms_integrations/cms_menus.py
+++ b/chameleon_cms_integrations/cms_menus.py
@@ -103,7 +103,7 @@ class UserMenu(CMSAttachMenu):
             _("Webinars"),
             "https://www.chameleoncloud.org/learn/webinars/",
             menu_id,
-            dashboard_id
+            dashboard_id,
         )
         nodes.append(n)
 

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -391,7 +391,6 @@ def share_artifact(request, artifact):
                         reverse("sharing_portal:share", args=[artifact["uuid"]])
                     )
 
-
             if patches:
                 try:
                     trovi.patch_artifact(


### PR DESCRIPTION
Balance service doesn't allow user to create/extend lease beyond
active allocation expiration date - even though they have approved
allocation afterward. We fixed the issue by checking the
consecutive approved allocation.