### PR TITLE
Fix tag widget in artifact edit form

### DIFF
--- a/sharing_portal/forms.py
+++ b/sharing_portal/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.forms import widgets
+from django.forms import widgets, CheckboxSelectMultiple
 
 from projects.models import Project
 from util.project_allocation_mapper import ProjectAllocationMapper
@@ -29,7 +29,10 @@ class ArtifactForm(forms.Form):
             for t in trovi.list_tags(request.session.get("trovi_token"))
         ]
         self.fields["tags"] = forms.MultipleChoiceField(
-            choices=available_labels, required=False
+            widget=CheckboxSelectMultiple,
+            choices=available_labels,
+            required=False,
+            initial=artifact["tags"] if artifact else [],
         )
         if artifact:
             self.fields["title"].initial = artifact["title"]


### PR DESCRIPTION
There was previously a bug with the tag widget, which would cause it to initially be empty. Because of this, saving the artifact without any changes would cause the tags to be removed from the artifact. Now, the widget will be initialized with whatever tags the artifact had previously.

The widget has also been changed to a multiple-choice checkbox. The multi-select menu thing seems more difficult to use, as it required users to CTRL+Click on multiple options in a tiny scrolling field. It was also not possible to view all of the tags at once in this view.
