### PR TITLE
Fix crash on artifact edit

### DIFF
--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -327,16 +327,12 @@ def edit_artifact(request, artifact):
             # Return to Trovi home page
             return HttpResponseRedirect(reverse("sharing_portal:index_all"))
 
-        artifact, errors = _handle_artifact_forms(
+        artifact = _handle_artifact_forms(
             request, form, artifact=artifact, authors_formset=authors_formset
         )
-        if errors:
-            for e in errors:
-                messages.error(request, e)
-        else:
-            messages.add_message(
-                request, messages.SUCCESS, "Successfully saved artifact."
-            )
+        messages.add_message(
+            request, messages.SUCCESS, "Successfully saved artifact."
+        )
         return HttpResponseRedirect(
             reverse("sharing_portal:detail", args=[artifact["uuid"]])
         )

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -330,9 +330,7 @@ def edit_artifact(request, artifact):
         artifact = _handle_artifact_forms(
             request, form, artifact=artifact, authors_formset=authors_formset
         )
-        messages.add_message(
-            request, messages.SUCCESS, "Successfully saved artifact."
-        )
+        messages.add_message(request, messages.SUCCESS, "Successfully saved artifact.")
         return HttpResponseRedirect(
             reverse("sharing_portal:detail", args=[artifact["uuid"]])
         )


### PR DESCRIPTION
The error handling for artifact edits was not updated in line with the changes from ccee53b5813872a62b210256c2e765d2ce975cf9.
