### PR TITLE
Pin node version to gallium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ARG NODE_IMG=node
-ARG NODE_VER=lts
+ARG NODE_VER_NAME=lts-gallium
 ARG PY_IMG=python
 ARG PY_VER=3.7.9-stretch
 
-FROM ${NODE_IMG}:${NODE_VER} as client
+FROM ${NODE_IMG}:${NODE_VER_NAME} as client
 WORKDIR /project
 COPY package.json yarn.lock ./
 RUN yarn install
@@ -11,11 +11,10 @@ COPY . ./
 RUN yarn build --production
 
 FROM ${PY_IMG}:${PY_VER}
-ARG NODE_VER=lts
 # Set shell to use for run commands
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VER}.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 # Install apt packages
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
See https://github.com/nodejs/Release for timeline. Active node LTS became Node 18 on 2022-10-25, while 16 (gallium) still support for another year. NODE_VER was having templating errors, and so had to hardcode 16.