### PR TITLE
Add roles to artifact edit form

### DIFF
--- a/sharing_portal/forms.py
+++ b/sharing_portal/forms.py
@@ -16,7 +16,7 @@ class ArtifactForm(forms.Form):
     title = forms.CharField(label="Title")
     short_description = forms.CharField(label="Short Description")
     long_description = forms.CharField(
-        label="Long Description", widget=forms.Textarea()
+        label="Long Description", widget=forms.Textarea(), required=False
     )
 
     def __init__(self, *args, **kwargs):
@@ -44,6 +44,7 @@ class AuthorForm(forms.Form):
     full_name = forms.CharField(label="Full Name")
     email = forms.CharField(label="Email")
     affiliation = forms.CharField(label="Affiliation", required=False)
+    prefix = "author"
 
     def __init__(self, *args, **kwargs):
         author = kwargs.pop("initial", None)
@@ -61,6 +62,33 @@ AuthorFormset = forms.formset_factory(
 
 AuthorCreateFormset = forms.formset_factory(
     form=AuthorForm, can_delete=False, extra=2, min_num=1
+)
+
+
+class RolesForm(forms.Form):
+    email = forms.EmailField(
+        label="Email",
+        required=True,
+    )
+    roles = forms.MultipleChoiceField(
+        label="Roles",
+        widget=CheckboxSelectMultiple,
+        required=False,
+        choices=[(role, role) for role in ("collaborator", "administrator")],
+    )
+    prefix = "role"
+
+    def __init__(self, *args, **kwargs):
+        roles = kwargs.pop("initial", None)
+        super().__init__(*args, **kwargs)
+
+        if roles:
+            self.fields["email"].initial = roles["email"]
+            self.fields["roles"].initial = roles["roles"]
+
+
+RoleFormset = forms.formset_factory(
+    form=RolesForm, can_delete=False, extra=2, min_num=1
 )
 
 

--- a/sharing_portal/templates/sharing_portal/edit.html
+++ b/sharing_portal/templates/sharing_portal/edit.html
@@ -40,9 +40,9 @@
         </fieldset>
         {% endfor %}
         <h4>Roles</h4>
-        Assign roles to various users, allowing them to collaborate on this artifact. <br><br>
-        The <b>collaborator</b> role allows users to edit artifact metadata, upload new versions, and share private artifacts. <br><br>
-        The <b>administrator</b> role allows users to control almost everything about the artifact.<br><br>
+        Assign roles to various users, allowing them to collaborate on this artifact. <br>
+        For more information on roles, see
+        <a href="https://chameleoncloud.readthedocs.io/en/latest/technical/sharing.html#trovi-roles">our documentation</a>.<br><br>
         {{ roles_formset.management_form }}
         {% for form in roles_formset.forms %}
         <fieldset class="form-group form-inline" prefix="role">

--- a/sharing_portal/templates/sharing_portal/edit.html
+++ b/sharing_portal/templates/sharing_portal/edit.html
@@ -35,7 +35,17 @@
         <h4>Authors</h4>
         {{ authors_formset.management_form }}
         {% for form in authors_formset.forms %}
-        <fieldset class="form-group form-inline">
+        <fieldset class="form-group form-inline" prefix="author">
+          {% bootstrap_form form show_label=False layout='inline' %}
+        </fieldset>
+        {% endfor %}
+        <h4>Roles</h4>
+        Assign roles to various users, allowing them to collaborate on this artifact. <br><br>
+        The <b>collaborator</b> role allows users to edit artifact metadata, upload new versions, and share private artifacts. <br><br>
+        The <b>administrator</b> role allows users to control almost everything about the artifact.<br><br>
+        {{ roles_formset.management_form }}
+        {% for form in roles_formset.forms %}
+        <fieldset class="form-group form-inline" prefix="role">
           {% bootstrap_form form show_label=False layout='inline' %}
         </fieldset>
         {% endfor %}

--- a/sharing_portal/trovi.py
+++ b/sharing_portal/trovi.py
@@ -329,6 +329,24 @@ def increment_metric_count(
         LOG.exception(e)
 
 
+def add_role(token, artifact_id, user, role):
+    json_data = {"user": user, "role": role}
+    res = requests.post(
+        url_with_token(f"/artifacts/{artifact_id}/roles/", token), json=json_data
+    )
+    check_status(res, requests.codes.no_content)
+    return None
+
+
+def remove_role(token, artifact_id, user, role):
+    res = requests.delete(
+        url_with_token(f"/artifacts/{artifact_id}/roles", token)
+        + f"&user={user}&role={role}"
+    )
+    check_status(res, requests.codes.no_content)
+    return None
+
+
 def parse_project_urn(project_urn):
     provider, project_id = project_urn.split(":", 4)[3:]
     return {
@@ -351,6 +369,10 @@ def parse_contents_urn(contents_urn):
         "provider": provider,
         "id": contents_id,
     }
+
+
+def get_user_info(user_urn):
+    return user_urn.split(":", 4)[-1]
 
 
 def get_contents_url_info(token, contents_urn, sharing_key=None):
@@ -408,3 +430,7 @@ def migrate_to_zenodo(token, artifact_uuid, slug):
     )
     check_status(res, requests.codes.accepted)
     return res.json()
+
+
+def to_user_urn(username):
+    return f"urn:trovi:user:chameleon:{username}"

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 
 from django.conf import settings
 from django.contrib import messages
@@ -24,6 +25,7 @@ from .forms import (
     ZenodoPublishFormset,
     RequestDaypassForm,
     ReviewDaypassForm,
+    RoleFormset,
 )
 from .models import Artifact, DaypassRequest, DaypassProject
 from . import trovi
@@ -270,13 +272,30 @@ def _delete_artifact_version(request, version):
         return False
 
 
+def _convert_artifact_roles_to_formset_roles(roles):
+    role_formset_data = defaultdict(list)
+    for role in roles:
+        role_formset_data[role["user"]].append(role["role"])
+    return [
+        {"email": trovi.get_user_info(user), "roles": role_formset_data[user]}
+        for user in role_formset_data
+    ]
+
+
 @login_required
 @handle_trovi_errors
 @with_trovi_token
 @check_edit_permission
 def edit_artifact(request, artifact):
     if request.method == "POST":
-        authors_formset = AuthorFormset(request.POST, initial=artifact["authors"])
+        authors_formset = AuthorFormset(
+            request.POST, initial=artifact["authors"], prefix="author"
+        )
+        roles_formset = RoleFormset(
+            request.POST,
+            initial=_convert_artifact_roles_to_formset_roles(artifact["roles"]),
+            prefix="role",
+        )
 
         form = ArtifactForm(request.POST, artifact=artifact, request=request)
 
@@ -327,21 +346,33 @@ def edit_artifact(request, artifact):
             # Return to Trovi home page
             return HttpResponseRedirect(reverse("sharing_portal:index_all"))
 
-        artifact = _handle_artifact_forms(
-            request, form, artifact=artifact, authors_formset=authors_formset
+        saved = _handle_artifact_forms(
+            request,
+            form,
+            artifact=artifact,
+            authors_formset=authors_formset,
+            roles_formset=roles_formset,
         )
-        messages.add_message(request, messages.SUCCESS, "Successfully saved artifact.")
+        if saved:
+            messages.add_message(
+                request, messages.SUCCESS, "Successfully saved artifact."
+            )
         return HttpResponseRedirect(
             reverse("sharing_portal:detail", args=[artifact["uuid"]])
         )
 
     authors_formset = AuthorFormset(initial=artifact["authors"])
-    form = ArtifactForm(artifact=artifact, request=request)
+    roles_formset = RoleFormset(
+        initial=_convert_artifact_roles_to_formset_roles(artifact["roles"]),
+        prefix="role",
+    )
+    form = ArtifactForm(artifact=artifact, request=request, prefix="author")
     template = loader.get_template("sharing_portal/edit.html")
     context = {
         "artifact_form": form,
         "artifact": artifact,
         "authors_formset": authors_formset,
+        "roles_formset": roles_formset,
     }
 
     return HttpResponse(template.render(context, request))
@@ -353,7 +384,6 @@ def edit_artifact(request, artifact):
 @login_required
 def share_artifact(request, artifact):
     if request.method == "POST":
-
         form = ShareArtifactForm(request, request.POST)
         z_form = ZenodoPublishFormset(
             request.POST, artifact_versions=artifact["versions"]
@@ -941,37 +971,89 @@ def _artifact_version(artifact, version_slug=None):
     return None
 
 
-def _handle_artifact_forms(request, artifact_form, authors_formset=None, artifact=None):
+def _handle_artifact_forms(
+    request, artifact_form, authors_formset=None, roles_formset=None, artifact=None
+):
+    patches = []
+    form_errors = []
     if artifact_form.is_valid():
-        patches = []
         keys = ["title", "short_description", "long_description", "title", "tags"]
         for key in keys:
             value = artifact_form.cleaned_data[key]
             if artifact.get(key) != value:
                 patches.append({"op": "replace", "path": f"/{key}", "value": value})
 
-        if authors_formset:
-            if authors_formset.is_valid():
-                authors = []
-                for author in authors_formset.cleaned_data:
-                    if author and not author["DELETE"]:
-                        del author["DELETE"]
-                        authors.append(author)
-                if authors and authors != artifact["authors"]:
-                    patches.append(
-                        {"op": "replace", "path": "/authors", "value": authors}
-                    )
+    if authors_formset:
+        if not authors_formset.is_valid():
+            form_errors += list(authors_formset.errors)
+        else:
+            authors = []
+            for author in authors_formset.cleaned_data:
+                if author and not author["DELETE"]:
+                    del author["DELETE"]
+                    authors.append(author)
+            if authors and authors != artifact["authors"]:
+                patches.append({"op": "replace", "path": "/authors", "value": authors})
+
+        add_roles = []
+        remove_roles = []
+        if roles_formset:
+            if not roles_formset.is_valid():
+                form_errors += list(roles_formset.errors)
             else:
-                for error in authors_formset.errors:
+                # Map roles on the existing artifact by email -> list of roles
+                artifact_roles = {
+                    r["email"]: r["roles"]
+                    for r in _convert_artifact_roles_to_formset_roles(artifact["roles"])
+                }
+                new_roles = roles_formset.cleaned_data
+                for user_roles in [role for role in new_roles if role]:
+                    user = user_roles["email"]
+                    for role in user_roles["roles"]:
+                        # If any of the newly defined roles for the user are not already
+                        # on the artifact, that means the user wants to assign a new
+                        # role to a user
+                        if role not in artifact_roles.get(user, []):
+                            add_roles.append(
+                                {"user": trovi.to_user_urn(user), "role": role}
+                            )
+                    for role in artifact_roles.get(user, []):
+                        # If any of the roles on the existing artifact are not in the
+                        # newly defined roles, it means the user wants to unassign
+                        # the role from the user
+                        if role not in user_roles["roles"]:
+                            remove_roles.append(
+                                {"user": trovi.to_user_urn(user), "role": role}
+                            )
+
+        if form_errors:
+            for error in form_errors:
+                if error:
                     messages.error(request, error)
-                return artifact
+            return False
 
         if patches:
             trovi.patch_artifact(
                 request.session.get("trovi_token"), artifact["uuid"], patches
             )
 
-    return artifact
+        for role in add_roles:
+            trovi.add_role(
+                request.session.get("trovi_token"),
+                artifact["uuid"],
+                role["user"],
+                role["role"],
+            )
+
+        for role in remove_roles:
+            trovi.remove_role(
+                request.session.get("trovi_token"),
+                artifact["uuid"],
+                role["user"],
+                role["role"],
+            )
+
+    return True
 
 
 def _request_artifact_dois(request, artifact, request_forms=[]):


### PR DESCRIPTION
Users will now be able to assign and unassign roles from users when editing their artifacts.

The roles function very similarly to the authors, where new input fields are added statically.

![image](https://user-images.githubusercontent.com/14908880/227280042-0f6122fe-58d2-443a-9d81-7f6e5363ff5a.png)

