### PR TITLE
Add bulk remove users button to project page

### DIFF
--- a/projects/static/projects/js/bulk_remove.js
+++ b/projects/static/projects/js/bulk_remove.js
@@ -1,0 +1,8 @@
+'use strict';
+(function( window, $, undefined ) {
+  $('button[name="remove_bulk_users_popup"]').on('click', function(e) {
+    e.preventDefault();
+    var $popup = $("#bulk_remove_popup");
+    $popup.modal("show");
+  });
+})( this, $ );

--- a/projects/templates/projects/bulk_remove_modal.html
+++ b/projects/templates/projects/bulk_remove_modal.html
@@ -1,0 +1,22 @@
+{% load bootstrap3 %}
+<div id="bulk_remove_popup" class="modal fade" role="dialog" style="padding-top: 5%">
+  <div class="modal-dialog" style="width: 40%">
+    <div class="modal-content">
+      <form class="form" role="form" method="post">
+        <div class="modal-body">
+          <p>
+            This will remove all users from your project who do not have the "Manager" role.
+            Are you sure you want to do this?
+          </p>
+          {% csrf_token %}
+        </div>
+        <div class="modal-footer">
+          <div class="form-group">
+            <button type="button" class="btn btn-default" data-dismiss="modal">No, Cancel</button>
+            <button type="submit" class="btn btn-danger" name="remove_bulk_users">Yes, Remove</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/projects/templates/projects/view_project.html
+++ b/projects/templates/projects/view_project.html
@@ -143,9 +143,11 @@
   <div class="form-group">
     <button type="submit" class="btn btn-default" name="add_user">Add user</button>
     <button class="btn btn-default" name="add_bulk_users_popup">Add multiple users</button>
+    <button class="btn btn-danger" name="remove_bulk_users_popup">Remove multiple users</button>
   </div>
 </form>
 {% include "projects/bulk_invite_modal.html" %}
+{% include "projects/bulk_remove_modal.html" %}
 {% endif %}
 
 <br>
@@ -255,4 +257,5 @@
 <script src="{% static 'projects/js/allocations.js' %}" type="text/javascript"></script>
 <script src="{% static 'projects/js/members.js' %}" type="text/javascript"></script>
 <script src="{% static 'projects/js/bulk_invite.js' %}" type="text/javascript"></script>
+<script src="{% static 'projects/js/bulk_remove.js' %}" type="text/javascript"></script>
 {% endblock %}


### PR DESCRIPTION
Managing users will now be able to remove all non-manager users with a single button click. It is very similar to the existing bulk add users button.

![image](https://user-images.githubusercontent.com/14908880/227349396-df70c099-c8cc-49b7-b012-009944609ac0.png)
![image](https://user-images.githubusercontent.com/14908880/227349499-a4506031-62f4-41c8-b4a0-cf982092189a.png)

