### PR TITLE
Update Trovi sidebar

### DIFF
--- a/sharing_portal/static/sharing_portal/artifacts.css
+++ b/sharing_portal/static/sharing_portal/artifacts.css
@@ -162,6 +162,30 @@
     color: var(--grey-dark);
 }
 
+.sidebarNav__separator {
+    border-top: 2px solid var(--grey-light);
+} .sidebarNav__separator h4 {
+    color: var(--accent-primary);
+}
+
+.sidebarNav__tags {
+    flex: 1;
+    text-align: left;
+} .sidebarNav__tags > a {
+    display: inline-block;
+    background: var(--grey-light);
+    text-decoration: none !important;
+    color: inherit !important;
+    border-radius: 0.5rem;
+    font-size: 1.4rem;
+    padding: 0.2rem 1rem;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+} .sidebarNav__tags > a:last-child {
+    margin-right: 0;
+}
+
+
 .artifactDetail {
     background: #ffffff;
     padding: 1.5rem;

--- a/sharing_portal/static/sharing_portal/artifacts.css
+++ b/sharing_portal/static/sharing_portal/artifacts.css
@@ -164,6 +164,7 @@
 
 .sidebarNav__separator {
     border-top: 2px solid var(--grey-light);
+    margin-top: 11px;
 } .sidebarNav__separator h4 {
     color: var(--accent-primary);
 }
@@ -171,6 +172,7 @@
 .sidebarNav__tags {
     flex: 1;
     text-align: left;
+    margin-bottom: 0.5rem;
 } .sidebarNav__tags > a {
     display: inline-block;
     background: var(--grey-light);

--- a/sharing_portal/templates/sharing_portal/index.html
+++ b/sharing_portal/templates/sharing_portal/index.html
@@ -92,10 +92,13 @@
     <div class="sidebarHeading">
       <h1>Trovi</h1>
       <p>
-        A collection of shared artifacts you can launch on Chameleon.
-        <a href="https://chameleoncloud.readthedocs.io/en/latest/technical/sharing.html" rel="noopener noreferrer">
-          Learn how to contribute on the docs.
-        </a>
+        This page is powered by <a href="https://chameleoncloud.gitbook.io/trovi/" target="_blank">Trovi</a>,
+        an open platform for practical reproducibility. These artifacts are packaged experimental environments
+        which are ready for reproduction at the click of a button. For more information on how to use Trovi,
+        please refer to our
+        <a href="https://chameleoncloud.readthedocs.io/en/latest/technical/sharing.html" target="_blank">documentation</a>
+        or
+        <a href="https://chameleoncloud.org/blog/2022/06/01/sharing-experiments-with-trovi/" target="_blank">blog</a>.
       </p>
     </div>
 
@@ -111,6 +114,14 @@
     <a href="{% url 'sharing_portal:create_artifact' %}">
       <button class="btn btn-success">Import Artifact</button>
     </a>
+    <div class="sidebarNav__separator">
+      <h4>Tags</h4>
+      {% for tag in tags %}
+      <div class="sidebarNav__tags">
+        <a href="{% url 'sharing_portal:index_all' %}?filter=tag:{{ tag|urlencode }}">{{ tag }}</a>
+      </div>
+      {% endfor %}
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/sharing_portal/trovi.py
+++ b/sharing_portal/trovi.py
@@ -100,7 +100,7 @@ def list_artifacts(token, sort_by="updated_at"):
     return res.json()["artifacts"]
 
 
-def list_tags(token):
+def list_tags(token=None):
     res = requests.get(url_with_token("/meta/tags/", token))
     check_status(res, requests.codes.ok)
     return res.json()["tags"]

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -189,6 +189,7 @@ def _render_list(request, artifacts):
         "hub_url": settings.ARTIFACT_SHARING_JUPYTERHUB_URL,
         "artifacts": other_artifacts,
         "featured_artifacts": featured_artifacts,
+        "tags": [t["tag"] for t in trovi.list_tags()],
     }
 
     return HttpResponse(template.render(context, request))


### PR DESCRIPTION
The text in the sidebar is now more descriptive, and contains helpful links.

Trovi tags are also listed below the import button. They function just the same as the tags shown on individual artifacts.
