### PR TITLE
fix enforcement exception message

### DIFF
--- a/balance_service/enforcement/exceptions.py
+++ b/balance_service/enforcement/exceptions.py
@@ -21,7 +21,7 @@ class EnforcementException(Exception):
         if "code" not in self.kwargs:
             self.kwargs["code"] = self.code
 
-        if not message:
+        if not self.message:
             try:
                 self.message = self.msg_fmt % kwargs
             except KeyError:
@@ -33,7 +33,7 @@ class EnforcementException(Exception):
 
                 self.message = self.msg_fmt
 
-        super(EnforcementException, self).__init__(message)
+        super(EnforcementException, self).__init__(self.message)
 
 
 class BillingError(EnforcementException):

--- a/balance_service/enforcement/exceptions.py
+++ b/balance_service/enforcement/exceptions.py
@@ -15,7 +15,8 @@ class EnforcementException(Exception):
 
     def __init__(self, message=None, **kwargs):
         self.kwargs = kwargs
-        self.message = message
+        if message:
+            self.message = message
 
         if "code" not in self.kwargs:
             self.kwargs["code"] = self.code

--- a/balance_service/enforcement/usage_enforcement.py
+++ b/balance_service/enforcement/usage_enforcement.py
@@ -332,6 +332,8 @@ class UsageEnforcer(object):
         lease_end = self._convert_to_localtime(
             self._date_from_string(lease["end_date"])
         )
+        LOG.info(f"Allocation dates {lease} {lease['end']}, {alloc.expiration_date}")
+        LOG.info(f"is approved alloc - {approved_alloc}")
         if (approved_alloc and lease_end > approved_alloc.expiration_date) or (
             not approved_alloc and lease_end > alloc.expiration_date
         ):

--- a/balance_service/enforcement/usage_enforcement.py
+++ b/balance_service/enforcement/usage_enforcement.py
@@ -332,8 +332,6 @@ class UsageEnforcer(object):
         lease_end = self._convert_to_localtime(
             self._date_from_string(lease["end_date"])
         )
-        LOG.info(f"Allocation dates {lease} {lease['end']}, {alloc.expiration_date}")
-        LOG.info(f"is approved alloc - {approved_alloc}")
         if (approved_alloc and lease_end > approved_alloc.expiration_date) or (
             not approved_alloc and lease_end > alloc.expiration_date
         ):

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -910,7 +910,7 @@ if DEBUG:
 # Balance Service
 ########
 ALLOWED_OPENSTACK_SERVICE_USERS = os.environ.get(
-    "ALLOWED_OPENSTACK_SERVICE_USERS", ["blazar", "portal"]
+    "ALLOWED_OPENSTACK_SERVICE_USERS", ["blazar", "portal", "smoke-tests"]
 )
 
 ########


### PR DESCRIPTION
`LeasePastExpirationError` is not sending the right message on raising the exception
Fix `EnforcementException` to use the message of subclass

when a `message` is not passed, it will be `None` and it overwriting `self.message`. This fix will only overwrite it if `message` is passed with contents.