### PR TITLE
reformat guidelines for add project page

### DIFF
--- a/projects/templates/projects/add_publications.html
+++ b/projects/templates/projects/add_publications.html
@@ -36,21 +36,28 @@
   </table>
 </div>
 
+<div class="row">
+  <div class="col-md-12">
+    <h4>Guidelines for Submission:</h4>
+    <ul>
+      <li><b>Please ensure that the publications you upload are directly related
+         to research or projects that have utilized Chameleon resources.</b></li>
+      <li>Publications BibTeX Format:</li>
+      <ul>
+        <li>Please enter your publication(s) in BibTeX format in the field below.
+          If available, include a link to the publication using the <code>note</code>
+          or <code>howpublished</code> field with the <a href="https://ctan.org/pkg/url">url package</a>.</li>
+      </ul>
+    </ul>
+    <p>Your cooperation in adhering to these guidelines is appreciated as it
+      helps maintain the integrity and relevance of the publications section.</p>
+  </div>
+</div>
+
 <form method="post">
   {% csrf_token %}
-
-  <h4>Publications BibTeX Format:</h4>
-  <p>Please enter your publication(s) in BibTeX format in the field below. If available, include a link to the publication using the <code>note</code> or <code>howpublished</code> field with the <a href="https://ctan.org/pkg/url">url package</a>.</p>
   {% bootstrap_form pubs_form %}
-  <h4>Guidelines for Submission:</h4>
-  <ul>
-    <li>Please ensure that the publications you upload are directly related to research or projects that have utilized Chameleon resources.</li>
-    <li>Avoid duplicate submissions by checking if your publication is already listed <a href="https://chameleoncloud.org/user/projects/chameleon-used-research/" target="_blank">here</a>.</li>
-    <li>In addition, it helps us a lot when you cite the Chameleon paper. Please refer <a href="https://chameleoncloud.org/learn/frequently-asked-questions/#toc-how-should-i-acknowledge-chameleon-" target="_blank">to the FAQ</a> on how to acknowledge and cite Chameleon.</li>
-  </ul>
-
-  <p>Your cooperation in adhering to these guidelines is appreciated as it helps maintain the integrity and relevance of the publications section.
-
+  
   <div class="form-group">
     <button type="submit" class="btn btn-success">Add</button>
   </div>


### PR DESCRIPTION
<img width="1211" alt="image" src="https://github.com/ChameleonCloud/portal/assets/20154899/3918eb9a-70b4-4581-a1c0-419e9661feea">

The guidelines page will look like the above after the changes.
Removed the line that asks users to check for duplicates(this should be done by us)
Removed the line that lets users know how to cite chameleon