### PR TITLE
Changes to show Reproducible badge in trovi page

### DIFF
--- a/sharing_portal/admin.py
+++ b/sharing_portal/admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 
-from .models import DaypassRequest, FeaturedArtifact
+from .models import DaypassRequest, FeaturedArtifact, ArtifactBadge
 
 admin.site.register(DaypassRequest)
 
 admin.site.register(FeaturedArtifact)
+
+admin.site.register(ArtifactBadge)

--- a/sharing_portal/models.py
+++ b/sharing_portal/models.py
@@ -82,6 +82,37 @@ class Label(models.Model):
         return self.label
 
 
+class ArtifactBadge(models.Model):
+    """
+    Represents artifact badges
+    """
+    artifact_uuid = models.CharField(max_length=36, null=True)
+    BADGE_REPRODUCIBLE_IN_TROVI = "Reproducible"
+    BADGE = (
+        (BADGE_REPRODUCIBLE_IN_TROVI, "Reproducible"),
+    )
+    badge_name = models.CharField(max_length=50, blank=False, choices=BADGE)
+    STATUS_PENDING = "pending"
+    STATUS_REJECTED = "rejected"
+    STATUS_APPROVED = "approved"
+    STATUS_DELETED = "deleted"
+    STATUS = (
+        (STATUS_PENDING, "pending"),
+        (STATUS_REJECTED, "rejected"),
+        (STATUS_APPROVED, "approved"),
+        (STATUS_APPROVED, "deleted"),
+    )
+    status = models.CharField(max_length=50, blank=False, choices=STATUS)
+    requested_on = models.DateTimeField(auto_now_add=True)
+    requested_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE
+    )
+    decision_at = models.DateTimeField(null=True)
+    decision_summary = models.TextField(blank=True, null=True)
+    deleted_at = models.DateTimeField(blank=True, null=True)
+
+
+
 class Artifact(models.Model):
     """
     Represents artifacts

--- a/sharing_portal/templates/sharing_portal/includes/stats.html
+++ b/sharing_portal/templates/sharing_portal/includes/stats.html
@@ -42,5 +42,11 @@
       <img src="{% static 'images/logo-small.png' %}" alt="Small Chameleon logo">
     </a>
     {% endif %}
+    {% if artifact.has_reproducible_badge %}
+    <a href="{% url 'sharing_portal:index_all' %}?filter=badge:reproducible" class="artifactStats__chameleonSupported" title="This artifact is practically reproducible">
+      <img src="{% static 'images/repeto-logo-small2.png' %}" alt="Small Repeto logo">
+    </a>
+    {% endif %}
+
   </div>
 </div>

--- a/sharing_portal/templates/sharing_portal/index.html
+++ b/sharing_portal/templates/sharing_portal/index.html
@@ -122,6 +122,16 @@
       </div>
       {% endfor %}
     </div>
+    <div class="sidebarNav__separator">
+      <h4>Badges</h4>
+      {% for badge in badges %}
+      <div class="sidebarNav__tags">
+        <a href="{% url 'sharing_portal:index_all' %}?filter=badge:{{ badge|urlencode }}">{{badge}}
+            <img src="{% static 'images/repeto-logo-small2.png' %}" alt="Small Repeto logo">
+        </a>
+      </div>
+      {% endfor %}
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -39,7 +39,7 @@ from .forms import (
     ReviewDaypassForm,
     RoleFormset,
 )
-from .models import Artifact, DaypassRequest, DaypassProject, FeaturedArtifact
+from .models import Artifact, ArtifactBadge, DaypassRequest, DaypassProject, FeaturedArtifact
 from .zenodo import ZenodoClient
 
 LOG = logging.getLogger(__name__)
@@ -190,16 +190,24 @@ def _render_list(request, artifacts):
         "artifacts": other_artifacts,
         "featured_artifacts": featured_artifacts,
         "tags": [t["tag"] for t in trovi.list_tags()],
+        "badges": list(ArtifactBadge.objects.values_list('badge_name', flat=True).distinct()),
     }
 
     return HttpResponse(template.render(context, request))
 
 
 def _compute_artifact_fields(artifact):
+    artifact["has_reproducible_badge"] = ArtifactBadge.objects.filter(
+        artifact_uuid=artifact["uuid"],
+        badge_name=ArtifactBadge.BADGE_REPRODUCIBLE_IN_TROVI,
+        status=ArtifactBadge.STATUS_APPROVED
+    ).exists()
     terms = artifact["title"].lower().split()
     terms.extend([f"tag:{label.lower()}" for label in artifact["tags"]])
     for name in [author["full_name"] for author in artifact["authors"]]:
         terms.extend(name.lower().split(" "))
+    if artifact["has_reproducible_badge"]:
+        terms.extend(["badge:reproducible"])
     artifact["search_terms"] = terms
     artifact["is_chameleon_supported"] = any(
         label == "chameleon" for label in artifact["tags"]
@@ -603,6 +611,8 @@ def artifact(request, artifact, version_slug=None):
     git_content = [method for method in access_methods if method["protocol"] == "git"]
     http_content = [method for method in access_methods if method["protocol"] == "http"]
 
+    # has_reproducible_badge, is_chameleon_supported needs to be populated
+    artifact = _compute_artifact_fields(artifact)
     context = {
         "artifact": artifact,
         "linked_project": trovi.get_linked_project(artifact),


### PR DESCRIPTION
- Create a Model `Artifactbadge` to hold all the details - name of the badge, who requested, when decision was made etc
- Show the logo in artifact list page
- Filter by badge similar to filter with tag
- Show the badge and chameleon logo in detail page