### PR TITLE
override delete publication method to change the status of the pub to be deleted

### DIFF
--- a/projects/models.py
+++ b/projects/models.py
@@ -320,12 +320,14 @@ class Publication(models.Model):
     STATUS_APPROVED = "APPROVED"
     STATUS_DUPLICATE = "DUPLICATE"
     STATUS_REJECTED = "REJECTED"
+    STATUS_DELETED = "DELETED"
 
     STATUSES = [
         (STATUS_SUBMITTED, "Submitted"),
         (STATUS_APPROVED, "Approved"),
         (STATUS_DUPLICATE, "Duplicate"),
         (STATUS_REJECTED, "Rejected"),
+        (STATUS_DELETED, "Deleted"),
     ]
 
     # keys to report in __repr__
@@ -368,6 +370,10 @@ class Publication(models.Model):
             for ck in self.PUBLICATION_REPORT_FIELDS
         ]
         return "\n" + "\n".join(lines)
+
+    def delete(self, using=None, keep_parents=False):
+        self.status = self.STATUS_DELETED
+        self.save()
 
     objects = PublicationManager()
 
@@ -435,7 +441,9 @@ class PublicationSource(models.Model):
     is_found_by_algorithm = models.BooleanField(default=False, null=False)
     cites_chameleon = models.BooleanField(default=False, null=False)
     acknowledges_chameleon = models.BooleanField(default=False, null=False)
-    approved_with = models.CharField(choices=APPROVED_WITH, max_length=30, null=True)
+    approved_with = models.CharField(
+        choices=APPROVED_WITH, max_length=30, null=True, blank=True
+    )
 
     class Meta:
         constraints = [

--- a/projects/models.py
+++ b/projects/models.py
@@ -371,7 +371,7 @@ class Publication(models.Model):
         ]
         return "\n" + "\n".join(lines)
 
-    def delete(self, using=None, keep_parents=False):
+    def delete_pub(self, using=None, keep_parents=False):
         self.status = self.STATUS_DELETED
         self.save()
 

--- a/projects/pub_views.py
+++ b/projects/pub_views.py
@@ -108,6 +108,7 @@ def user_publications(request):
                     "year": pub.year,
                     "nickname": project.nickname,
                     "chargeCode": project.charge_code,
+                    "status": pub.status,
                 }
             )
     return render(request, "projects/view_publications.html", context)

--- a/projects/pub_views.py
+++ b/projects/pub_views.py
@@ -89,7 +89,9 @@ def user_publications(request):
                 "to remove this publication. Please try again",
             )
     context["publications"] = []
-    pubs = Publication.objects.filter(added_by_username=request.user.username)
+    pubs = Publication.objects.filter(added_by_username=request.user.username).exclude(
+        status=Publication.STATUS_DELETED
+    )
     for pub in pubs:
         project = ProjectAllocationMapper.get_publication_project(pub)
         if project:

--- a/projects/pub_views.py
+++ b/projects/pub_views.py
@@ -80,7 +80,7 @@ def user_publications(request):
         try:
             del_pub_id = request.POST["pub_ref"]
             logger.debug("deleting publication with id {}".format(del_pub_id))
-            Publication.objects.get(pk=del_pub_id).delete()
+            Publication.objects.get(pk=del_pub_id).delete_pub()
         except Exception:
             logger.exception("Failed removing publication")
             messages.error(

--- a/projects/templates/projects/view_publications.html
+++ b/projects/templates/projects/view_publications.html
@@ -13,6 +13,7 @@
   <button type="submit" class="btn btn-xs btn-link" name="del_pub"><i class="fa fa-minus-square text-danger"></i><span class="sr-only">Remove publication</span></button>
 </form>
 <small>[{% if p.nickname %} {{p.nickname}} {% else %} {{ p.chargeCode }} {% endif %}]</small>
+<small>[{{p.status}}]</small>
 <a href="{{ p.link }}">{{ p.title }}</a>, {{ p.author }} In <i>{{ p.forum }}</i>. {{ p.month }} {{ p.year }}
 </p>
 


### PR DESCRIPTION
override delete publication method to change the status of the pub to be deleted

show publication status on the user list publications page

add blank=True to user publication source approved with - so the admin form does not have it as required

trello task - https://trello.com/c/HtV9BDCH/622-publications-admin-page-is-missing-columns