### PR TITLE
Fixes after run pubs

### DIFF
--- a/projects/models.py
+++ b/projects/models.py
@@ -332,6 +332,7 @@ class Publication(models.Model):
 
     # keys to report in __repr__
     PUBLICATION_REPORT_FIELDS = [
+        "id",
         "title",
         "author",
         "year",

--- a/projects/pub_views.py
+++ b/projects/pub_views.py
@@ -49,21 +49,21 @@ def _send_publication_notification(charge_code, pubs):
 def _send_duplicate_pubs_notification(charge_code, duplicate_pubs):
     subject = "Project {charge_code} plausible duplicate uploaded"
     formatted_duplicate_pubs = [
-        f"""
-        <li>{pub.__repr__()} <br>Found duplicate for <br>
-        {duplicate_pubs[pub]} <br><br></li>"
-        """.replace(
-            "\n", "<br>"
-        )
+        (
+            f"<li>{pub.__repr__()} <br>Found duplicate for <br>"
+            f"{duplicate_pubs[pub]} <br><br></li>"
+        ).replace("\n", "<br>")
         for pub in duplicate_pubs
     ]
     formatted_duplicate_pubs = formatted_duplicate_pubs
+    logger.error(f"{formatted_duplicate_pubs}")
     body = f"""
     <p>Please review the following publications which are plausible duplicates by
     project {charge_code}:
     <ul>{" ".join(formatted_duplicate_pubs)}</ul>
     </p>
     """
+    logger.error(body)
     send_mail(
         subject=subject,
         from_email=settings.DEFAULT_FROM_EMAIL,
@@ -150,7 +150,8 @@ def add_publications(request, project_id):
             messages.success(request, "Publication(s) added successfully")
             _send_publication_notification(project.chargeCode, new_pubs)
             duplicate_pubs = get_duplicate_pubs(new_pubs)
-            if duplicate_pubs:
+            # if any of the pubs have duplicates
+            if any(v for v in duplicate_pubs.values()):
                 _send_duplicate_pubs_notification(project.chargeCode, duplicate_pubs)
         else:
             messages.error(request, "Error adding publication(s)")

--- a/projects/pub_views.py
+++ b/projects/pub_views.py
@@ -56,14 +56,12 @@ def _send_duplicate_pubs_notification(charge_code, duplicate_pubs):
         for pub in duplicate_pubs
     ]
     formatted_duplicate_pubs = formatted_duplicate_pubs
-    logger.error(f"{formatted_duplicate_pubs}")
     body = f"""
     <p>Please review the following publications which are plausible duplicates by
     project {charge_code}:
     <ul>{" ".join(formatted_duplicate_pubs)}</ul>
     </p>
     """
-    logger.error(body)
     send_mail(
         subject=subject,
         from_email=settings.DEFAULT_FROM_EMAIL,

--- a/projects/user_publication/citation.py
+++ b/projects/user_publication/citation.py
@@ -50,7 +50,9 @@ def update_scopus_citation(pub, dry_run=True):
             scopus_pub = search_results[0]
     if scopus_pub:
         # Returns a tuple of (object, created)
-        existing_scopus_source = pub.sources.get_or_create(name=PublicationSource.SCOPUS)[0]
+        existing_scopus_source = pub.sources.get_or_create(
+            name=PublicationSource.SCOPUS
+        )[0]
         logger.info(
             f"update scopus citation number for "
             f"{pub.title} (id: {pub.id}) "

--- a/projects/user_publication/citation.py
+++ b/projects/user_publication/citation.py
@@ -138,7 +138,7 @@ def update_semantic_scholar_citation(pub, dry_run=True):
 
 
 def update_citation_numbers(dry_run=True):
-    gscholar = GoogleScholarHandlerr()
+    gscholar = GoogleScholarHandler()
     for pub in Publication.objects.filter(status=Publication.STATUS_APPROVED):
         try:
             update_scopus_citation(pub, dry_run)

--- a/projects/user_publication/deduplicate.py
+++ b/projects/user_publication/deduplicate.py
@@ -118,10 +118,10 @@ def review_duplicates(dry_run=True):
     Args:
         dry_run (bool, optional):
     """
-    # get all the publications that are to be checked for duplicates
+    # get all the recent publications that are to be checked for duplicates
     pubs_to_check_for_duplicates = Publication.objects.filter(
         checked_for_duplicates=False
-    ).order_by("id")
+    ).order_by("-id")
     print(f"{len(pubs_to_check_for_duplicates)} pubs to check for duplicates")
     pub_checked = 0
     for pub1 in pubs_to_check_for_duplicates:

--- a/projects/user_publication/deduplicate.py
+++ b/projects/user_publication/deduplicate.py
@@ -66,7 +66,6 @@ def get_duplicate_pubs(pubs=None):
         pubs_to_check_against = Publication.objects.filter(
             id__lt=pub1.id, year=pub1.year
         ).order_by("-id")
-
         duplicate_with_their_original_pubs_map[pub1] = get_originals_for_duplicate_pub(
             pub1, pubs_to_check_against
         )

--- a/projects/user_publication/deduplicate.py
+++ b/projects/user_publication/deduplicate.py
@@ -121,7 +121,7 @@ def review_duplicates(dry_run=True):
     # get all the recent publications that are to be checked for duplicates
     pubs_to_check_for_duplicates = Publication.objects.filter(
         checked_for_duplicates=False
-    ).order_by("-id")
+    ).order_by("id")
     print(f"{len(pubs_to_check_for_duplicates)} pubs to check for duplicates")
     pub_checked = 0
     for pub1 in pubs_to_check_for_duplicates:

--- a/projects/user_publication/deduplicate.py
+++ b/projects/user_publication/deduplicate.py
@@ -118,7 +118,7 @@ def review_duplicates(dry_run=True):
     Args:
         dry_run (bool, optional):
     """
-    # get all the recent publications that are to be checked for duplicates
+    # get all the publications that are to be checked for duplicates
     pubs_to_check_for_duplicates = Publication.objects.filter(
         checked_for_duplicates=False
     ).order_by("id")

--- a/projects/user_publication/gscholar.py
+++ b/projects/user_publication/gscholar.py
@@ -48,7 +48,6 @@ class GoogleScholarHandler(object):
                     self.retries = 0
                     break
             return resp
-
         return inner_f
 
     def _publication_id(self, pub: dict):
@@ -168,10 +167,9 @@ class GoogleScholarHandler(object):
             result_pub["bib"]["title"].lower(), pub.title.lower()
         ):
             return
-
         g_citations = result_pub.get("num_citations", 0)
         # Returns a tuple of (object, created)
-        existing_g_source = pub.sources.get_or_create(name=Publication.G_SCHOLAR)[0]
+        existing_g_source = pub.sources.get_or_create(name=PublicationSource.GOOGLE_SCHOLAR)[0]
         existing_citation_count = existing_g_source.citation_count
         if not dry_run:
             with transaction.atomic():

--- a/projects/user_publication/gscholar.py
+++ b/projects/user_publication/gscholar.py
@@ -48,6 +48,7 @@ class GoogleScholarHandler(object):
                     self.retries = 0
                     break
             return resp
+
         return inner_f
 
     def _publication_id(self, pub: dict):
@@ -169,7 +170,9 @@ class GoogleScholarHandler(object):
             return
         g_citations = result_pub.get("num_citations", 0)
         # Returns a tuple of (object, created)
-        existing_g_source = pub.sources.get_or_create(name=PublicationSource.GOOGLE_SCHOLAR)[0]
+        existing_g_source = pub.sources.get_or_create(
+            name=PublicationSource.GOOGLE_SCHOLAR
+        )[0]
         existing_citation_count = existing_g_source.citation_count
         if not dry_run:
             with transaction.atomic():

--- a/projects/user_publication/utils.py
+++ b/projects/user_publication/utils.py
@@ -294,7 +294,7 @@ class PublicationUtils:
         Returns:
             boolean
         """
-        if pub1.year != pub2.year:
+        if str(pub1.year) != str(pub2.year):
             return False
         if (
             PublicationUtils.how_similar(pub1.title, pub2.title)


### PR DESCRIPTION
Fixed a critical issue where `PublicationSource.SCOPUS` needs to be used instead of `Publication.SCOPUS`
Minor formatting fixes
Fixed the duplicate notification issue by changing the year to string `str(pub1.year) != str(pub2.year)` I am not sure why this is happening - this might be because `create_from_bibtex` is creating the model with year in string
Fixes `is_null` to `isnull`