### PR TITLE
Invitation admin features

### DIFF
--- a/projects/admin.py
+++ b/projects/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.urls import reverse
 from django.utils.html import format_html
 
 from projects.models import (

--- a/projects/admin.py
+++ b/projects/admin.py
@@ -2,8 +2,13 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
 
-from projects.models import (ChameleonPublication, Funding, Invitation,
-                             Publication, PublicationSource)
+from projects.models import (
+    ChameleonPublication,
+    Funding,
+    Invitation,
+    Publication,
+    PublicationSource,
+)
 from projects.views import resend_invitation
 
 
@@ -137,14 +142,12 @@ class InvitationAdmin(admin.ModelAdmin):
         "date_accepted",
         "status",
     ]
-    actions = ['resend_invitation']
+    actions = ["resend_invitation"]
 
     def invite_link(self, obj):
         if obj.status == Invitation.STATUS_ISSUED:
             url = obj.get_invite_url()
-            return format_html(
-                f'<a href="{url}" target="_blank">Invite Link</a>'
-            )
+            return format_html(f'<a href="{url}" target="_blank">Invite Link</a>')
         return ""
 
     @admin.display(description="Expiry")

--- a/projects/models.py
+++ b/projects/models.py
@@ -210,6 +210,24 @@ class Invitation(models.Model):
     def _is_expired(self):
         return self.date_expires < timezone.now()
 
+    def get_invite_url(self, request=None):
+        """Returns invitation URL
+
+        Args:
+            request (HttpRequest, optional): Returns absolute URL if the invitation.
+                Defaults to None.
+
+        Returns:
+            str
+        """
+        relative_url = reverse(
+            "projects:accept_invite",
+            kwargs={"invite_code": self.email_code}
+        )
+        if request:
+            return request.build_absolute_uri(relative_url)
+        return relative_url
+
 
 class JoinLink(models.Model):
     """

--- a/projects/models.py
+++ b/projects/models.py
@@ -221,8 +221,7 @@ class Invitation(models.Model):
             str
         """
         relative_url = reverse(
-            "projects:accept_invite",
-            kwargs={"invite_code": self.email_code}
+            "projects:accept_invite", kwargs={"invite_code": self.email_code}
         )
         if request:
             return request.build_absolute_uri(relative_url)

--- a/projects/views.py
+++ b/projects/views.py
@@ -281,12 +281,6 @@ def format_timedelta(timedelta_instance):
     return str(timedelta_instance).split(".")[0]
 
 
-def get_invite_url(request, code):
-    return request.build_absolute_uri(
-        reverse("projects:accept_invite", kwargs={"invite_code": code})
-    )
-
-
 def notify_join_request_user(django_request, join_request):
     project = join_request.join_link.project
     link = django_request.build_absolute_uri(
@@ -698,7 +692,7 @@ def add_project_invitation(
 def send_invitation_email(invitation, request):
     project_title = invitation.project.title
     project_charge_code = invitation.project.charge_code
-    url = get_invite_url(request, invitation.email_code)
+    url = invitation.get_invite_url(request)
     help_url = request.build_absolute_uri(reverse("djangoRT:mytickets"))
     subject = f'Invitation for project "{project_title}" ({project_charge_code})'
     body = f"""

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -22,7 +22,6 @@ from projects.models import Project
 from projects.util import get_project_members
 from projects.views import (
     add_project_invitation,
-    get_invite_url,
     manage_membership_in_scope,
     get_project_membership_managers,
     is_membership_manager,
@@ -1023,7 +1022,7 @@ def send_request_decision_mail(request, daypass_request, daypass_project):
         )
         daypass_request.invitation = invite
         daypass_request.save()
-        url = get_invite_url(request, invite.email_code)
+        url = invite.get_invite_url(request)
         artifact_url = request.build_absolute_uri(
             reverse("sharing_portal:detail", args=[artifact["uuid"]])
         )


### PR DESCRIPTION
display invite url in admin page of invitation

Resend invitation to multiple invitations (action)

This change so when a user did not receive a invitation for somereason, we can initate a resend so they can use it

use get_invite_url from invitation models in sharing views

![image](https://github.com/ChameleonCloud/portal/assets/20154899/49444713-ff49-40ce-bbd9-91ad9233b698)
![image](https://github.com/ChameleonCloud/portal/assets/20154899/d245e350-2c94-4d71-b0c8-e9b70b970395)
