### PR TITLE
Artifact stats detail page confusion fix

### DIFF
--- a/sharing_portal/templates/sharing_portal/detail.html
+++ b/sharing_portal/templates/sharing_portal/detail.html
@@ -47,10 +47,7 @@
           {{ artifact.long_description|markdown|safe }}
         </section>
 
-        <section class="artifactBody__authors">
-          <h4>Artifact stats</h4>
-          {% include 'sharing_portal/includes/stats.html' with artifact=artifact version=None %}
-        </section>
+        {% include 'sharing_portal/includes/stats.html' with artifact=artifact version=None %}
 
         {% if artifact.authors %}
         <section class="artifactBody__authors">

--- a/sharing_portal/templates/sharing_portal/detail.html
+++ b/sharing_portal/templates/sharing_portal/detail.html
@@ -47,7 +47,10 @@
           {{ artifact.long_description|markdown|safe }}
         </section>
 
-        {% include 'sharing_portal/includes/stats.html' with artifact=artifact version=version %}
+        <section class="artifactBody__authors">
+          <h4>Artifact stats</h4>
+          {% include 'sharing_portal/includes/stats.html' with artifact=artifact version=None %}
+        </section>
 
         {% if artifact.authors %}
         <section class="artifactBody__authors">
@@ -145,6 +148,10 @@ git checkout {{git_method.ref}}</code></pre>
         </li>
         {% endfor %}
       </ol>
+    </div>
+    <h4>Version Stats</h4>
+    <div style="margin-left: 0.5em">
+      {% include 'sharing_portal/includes/stats.html' with artifact=artifact version=version sidebar=True %}
     </div>
   </div>
 </div>

--- a/sharing_portal/templates/sharing_portal/includes/stats.html
+++ b/sharing_portal/templates/sharing_portal/includes/stats.html
@@ -33,17 +33,19 @@
     {% load trovi_filters %}
     <span class="artifactStats__updated">{{ artifact.updated_at | trovi_date_format }}</span>
   </div>
-  <div class="artifactStats__labels">
-    {% for label in artifact.tags %}
-    <a href="{% url 'sharing_portal:index_all' %}?filter=tag:{{ label|urlencode }}">{{ label }}</a>
-    {% endfor %}
-    {% for badge in artifact.badges %}
-    <a href="{% url 'sharing_portal:index_all' %}?filter=badge:{{ badge.badge.name|urlencode }}" class="artifactStats__chameleonSupported" title="{{badge.badge.description}}">
-      {% with 'images/'|add:badge.badge.name|add:'-logo-small.png' as logo_static %}
-        <img src="{% static logo_static %}" alt="Small {{badge.badge.name}} logo">
-      {% endwith %}
-    </a>
-    {% endfor %}
+  {% if not sidebar %}
+    <div class="artifactStats__labels">
+      {% for label in artifact.tags %}
+      <a href="{% url 'sharing_portal:index_all' %}?filter=tag:{{ label|urlencode }}">{{ label }}</a>
+      {% endfor %}
+      {% for badge in artifact.badges %}
+      <a href="{% url 'sharing_portal:index_all' %}?filter=badge:{{ badge.badge.name|urlencode }}" class="artifactStats__chameleonSupported" title="{{badge.badge.description}}">
+        {% with 'images/'|add:badge.badge.name|add:'-logo-small.png' as logo_static %}
+          <img src="{% static logo_static %}" alt="Small {{badge.badge.name}} logo">
+        {% endwith %}
+      </a>
+      {% endfor %}
 
-  </div>
+    </div>
+  {% endif %}
 </div>

--- a/sharing_portal/templates/sharing_portal/includes/stats.html
+++ b/sharing_portal/templates/sharing_portal/includes/stats.html
@@ -29,9 +29,11 @@
       -
     {% endif %}
     </span>
-    <span data-toggle="tooltip" data-placement="top" title="Versions - number of published versions"><i class="fa fa-files-o"></i> {{ artifact.versions | length }}</span>
     {% load trovi_filters %}
-    <span class="artifactStats__updated">{{ artifact.updated_at | trovi_date_format }}</span>
+    {% if not version %}
+    <span data-toggle="tooltip" data-placement="top" title="Versions - number of published versions"><i class="fa fa-files-o"></i> {{ artifact.versions | length }}</span>
+      <span data-toggle="tooltip" data-placement="top" title="Last Updated" class="artifactStats__updated">{{ artifact.updated_at | trovi_date_format }}</span>
+    {% endif %}
   </div>
   {% if not sidebar %}
     <div class="artifactStats__labels">


### PR DESCRIPTION
The artifact details page shows the version's stats which is confusing as the list page shows the artifact's stats and the details page shows different numbers

Also, update the tooltip for the artifact to show 'last updated at' 

Do not show the last update and version count for version stats

<img width="1175" alt="image" src="https://github.com/ChameleonCloud/portal/assets/20154899/223c13c2-3f8b-426b-97d0-5e0a41fe2fe4">
<img width="325" alt="image" src="https://github.com/ChameleonCloud/portal/assets/20154899/9906a3d7-3a58-43e3-b7c8-55c6386ff730">
