### PR TITLE
Ticket detail page, text is not wrapped - this fixes it

### DIFF
--- a/djangoRT/templates/djangoRT/ticketDetail.html
+++ b/djangoRT/templates/djangoRT/ticketDetail.html
@@ -21,7 +21,7 @@
               <small>{{history.Description}}</small>
             </h4>
 
-            <pre>{{ history.Content }}</pre>
+            <pre style="white-space: pre-wrap; word-break: normal; ">{{ history.Content }}</pre>
 
             {% if history.Attachments %}
               <h5>Attachments:</h5>


### PR DESCRIPTION
pre tag does not support text wrapping natively, adding a style to it to allow text wrapping

Before
![image](https://github.com/ChameleonCloud/portal/assets/20154899/ae122fa2-3beb-41d7-8cc8-859630f87f2d)
 After
![image](https://github.com/ChameleonCloud/portal/assets/20154899/402578a3-198d-42a5-a0b2-87feaa164f1b)
