### PR TITLE
using the version explicitly to eliminate the version validation error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@204a51a57a74d190b284a0ce69b44bc37201f343
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v2.0.2' # optional
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c


### PR DESCRIPTION
GitHub CI actions fails when installing cosign with error
`Unable to validate cosign version: 'v2.0.2'`
This fix will use the main branch of cosign while explicitly using the v2.0.2
Failed CI run - https://github.com/ChameleonCloud/portal/actions/runs/6735289506/job/18317029790#step:4:247