### PR TITLE
Added restart=always directive to celery docker-compose entry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
     depends_on:
       - mysql
       - redis
+    restart: always
   vue:
     image: node:lts
     command: sh -c 'yarn && yarn serve'


### PR DESCRIPTION
This change comes after a portal outage where celery did not come back on and new approved user projects were not moved to the active state.