### PR TITLE
Fix daypass projects to use daypass tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v2.0.2' # optional
+          cosign-release: 'v2.2.2' # optional
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -1248,8 +1248,8 @@ def create_supplemental_project_if_needed(request, artifact, project):
         # allocation.save()
 
         created_project = Project.objects.get(id=created_tas_project["id"])
-        daypss_tag_id = Tag.objects.get(name="Daypass")
-        mapper.update_project_tag(created_project.id, daypss_tag_id)
+        daypass_tag = Tag.objects.get(name="Daypass")
+        mapper.update_project_tag(created_project.id, daypass_tag.id)
         daypass_project = DaypassProject(
             artifact_uuid=artifact["uuid"], project=created_project
         )


### PR DESCRIPTION
When creating daypass project users encountered error like this

`TypeError: int() argument must be a string, a bytes-like object or a number, not 'Tag'`

This issue started after this update - https://github.com/ChameleonCloud/portal/commit/f1ec9cc86c707cdaa8a382190b47c96d5286c32a 