### PR TITLE
bump ga:cosign install fails in github action runner - fix version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v2.0.2' # optional
+          cosign-release: 'v2.2.2' # optional
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c


### PR DESCRIPTION
Looks like they fixed here - https://github.com/ossf/scorecard-action/issues/998

updating to a newer verison should not be a problem, so bumping up the verison of cosign