### PR TITLE
If Dup pub is approved, update original

### DIFF
--- a/projects/user_publication/deduplicate.py
+++ b/projects/user_publication/deduplicate.py
@@ -164,6 +164,8 @@ def review_duplicates(dry_run=True):
                     pub1.save()
                 elif is_duplicate == "y":
                     duplicate_pub, original_pub = pick_duplicate_from_pubs(pub1, opub)
+                    if duplicate_pub.status == Publication.STATUS_APPROVED:
+                        original_pub.status = Publication.STATUS_APPROVED
                     duplicate_pub.status = Publication.STATUS_DUPLICATE
                     duplicate_pub.checked_for_duplicates = True
                     original_pub.checked_for_duplicates = True

--- a/projects/views.py
+++ b/projects/views.py
@@ -412,11 +412,13 @@ def view_project(request, project_id):
                 keycloak_client.set_user_project_role(
                     role_username, get_charge_code(project), role_name
                 )
-                if role_name == 'manager':
+                if role_name == "manager":
                     # delete user budgets for the user if they are manager
                     user = User.objects.get(username=role_username)
                     try:
-                        user_budget = ChargeBudget.objects.get(user=user, project=portal_project)
+                        user_budget = ChargeBudget.objects.get(
+                            user=user, project=portal_project
+                        )
                     except ChargeBudget.DoesNotExist:
                         # the user does not have a budget created, no-op
                         pass
@@ -439,7 +441,7 @@ def view_project(request, project_id):
                 (
                     f"SU budget for user {budget_user.username} "
                     f"is currently set to {request.POST['su_budget_user']}"
-                )
+                ),
             )
         elif "default_su_budget" in request.POST:
             portal_project.default_su_budget = request.POST["default_su_budget"]


### PR DESCRIPTION
When a duplicate is marked as duplicate of a original, Update original as approved if the duplicate is originally Approved This would happen when original is a preprint and a user uploaded a published paper in a conference