### PR TITLE
Add membership count and index to users on project page

### DIFF
--- a/projects/templates/projects/view_project.html
+++ b/projects/templates/projects/view_project.html
@@ -156,19 +156,24 @@
 {% endif %}
 
 <br>
+
+<h4>{{ users | length }} users{% if invitations %}, {{ invitations | length }} pending invitations{% endif %}{% if join_requests %}, {{ join_requests | length }} requests{% endif %}</h4>
+
 <br>
 
 {% for u in users %}
   <div class="panel panel-default" style="background-color: transparent">
     <div class="panel-heading" style="background-color: #d9edf7;">
       <div class="row" align="center">
-        <div class="col-xs-4 col-sm-4">
+        <div class="col-xs-1 col-sm-1">#{{ forloop.counter }}</div>
+        <div class="col-xs-3 col-sm-3">
           {{ u.username }}
         </div>
-        <div class="col-xs-4 col-sm-4">
-          {{ u.first_name }}, {{ u.last_name }}
+        <div class="col-xs-3 col-sm-3">
+          {{ u.username }}
         </div>
-        <div class="col-xs-2 col-sm-2">
+        <div class="col-xs-3 col-sm-3">
+          {{ u.first_name }}, {{ u.last_name }}
         </div>
         <div class="col-xs-2 col-sm-2">
           {% if u.username == request.user.username or can_manage_project_membership  %}


### PR DESCRIPTION
Add the total members and an index next to users on the project overview page.

<img width="521" alt="image" src="https://github.com/ChameleonCloud/portal/assets/9397092/c11956cb-2dcb-4ae6-8ebb-ca4ee05d7f15">
