### PR TITLE
Add API for badges

### DIFF
--- a/sharing_portal/urls.py
+++ b/sharing_portal/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("import/git/<pk>", views.create_git_version, name="create_git_version"),
     path("create", views.create_artifact, name="create_artifact"),
     path("api/git/", views.get_remote_data, name="get_remote_git_data"),
+    path("api/badges", views.badges_api, name="badges"),
     path("<pk>", views.artifact, name="detail"),
     path("<pk>/launch", views.launch, name="launch"),
     path("<pk>/download", views.download, name="download"),

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -1393,3 +1393,29 @@ def download(request, artifact, version_slug=None):
     return HttpResponseRedirect(
         reverse("sharing_portal:detail", args=[artifact["uuid"]])
     )
+
+
+def badges_api(request):
+    return HttpResponse(
+        json.dumps({
+            "badges": [
+                {
+                    "name": b.name,
+                    "description": b.description,
+                    "redirect_link": b.redirect_link,
+                }
+                for b in Badge.objects.filter()
+            ],
+            "artifact_badges": [
+                {
+                    "artifact_uuid": a.artifact_uuid,
+                    "badge": a.badge.name,
+                } for a in
+                ArtifactBadge.objects.filter(
+                    status=ArtifactBadge.STATUS_APPROVED,
+                    deleted_at=None
+                )
+            ]
+        }),
+        content_type="application/json",
+    )


### PR DESCRIPTION
This will allow the new external trovi dashboard to integrate and use our authoritative badges.

Response structure:
```
{
  "badges": [
    {
      "name": "chameleon",
      "description": "for chameleon supported",
      "redirect_link": ""
    },
    {
      "name": "reproducible",
      "description": "repto badge",
      "redirect_link": ""
    }
  ],
  "artifact_badges": [
    {
      "artifact_uuid": "1",
      "badge": "chameleon"
    }
  ]
}
```