### PR TITLE
Refactor user permissions

### DIFF
--- a/projects/migrations/0017_add_chameleon_publications_and_pi_aliases.py
+++ b/projects/migrations/0017_add_chameleon_publications_and_pi_aliases.py
@@ -58,7 +58,7 @@ def create_pi_aliases(apps, _):
         return
     for alias in PI_ALIASES:
         if get_user_model().objects.filter(pk=alias["pi_id"]).exists():
-            pi_alias_model.objects.create((pi_alias_model(**alias)))
+            pi_alias_model.objects.create(**alias)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This fixes a bug where managers could do what they were supposed to. It seems this is caused by having 2 scopes in keycloak: `manage` and `manager-members`. We may have differentiated this at one point, but now we do now, there are PIs, managers, and members.

This introduces a class UserPermissions that we can use to set these, rather than having to parse keycloak scopes everywhere we want to use permissions.

This also fixes a small bug in a migration.