### PR TITLE
Add memcached library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2817,6 +2817,17 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pymemcache"
+version = "4.0.0"
+description = "A comprehensive, fast, pure Python memcached client"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pymemcache-4.0.0-py2.py3-none-any.whl", hash = "sha256:f507bc20e0dc8d562f8df9d872107a278df049fa496805c1431b926f3ddd0eab"},
+    {file = "pymemcache-4.0.0.tar.gz", hash = "sha256:27bf9bd1bbc1e20f83633208620d56de50f14185055e49504f4f5e94e94aff94"},
+]
+
+[[package]]
 name = "pymultidictionary"
 version = "1.2.4"
 description = "PyMultiDictionary is a Dictionary Module for Python 2 to get meanings, translations, synonyms and antonyms of words in 20 different languages"
@@ -4427,4 +4438,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.10.11"
-content-hash = "5ca427d0dd49377862a7997602c5517423f7a700e6f47b86da0ef0ddf80a5fc5"
+content-hash = "9893d84747577ea0abd2459530d3caaf57f11ddcb92ff70de4d6193255e01e1d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ jsonpatch = "^1.32"
 nltk = "^3.7"
 djangocms-snippet = "^3.1.0"
 scholarly = "^1.7.11"
+pymemcache = "^4.0.0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"


### PR DESCRIPTION
Django's built in module was removed in 4.0, and so this external library must now be included to continue to use memcached.

https://docs.djangoproject.com/en/5.1/topics/cache/#memcached