### PR TITLE
Fix help desk button for logged out users.

### DIFF
--- a/chameleon_cms_integrations/cms_menus.py
+++ b/chameleon_cms_integrations/cms_menus.py
@@ -21,7 +21,7 @@ class UserMenu(CMSAttachMenu):
         menu_id += 1
         n = NavigationNode(
             _("Help Desk"),
-            reverse("djangoRT:mytickets"),
+            reverse("djangoRT:ticketcreateguest"),
             menu_id,
             attr={"visible_for_anonymous": True, "class": "navbar-btn-alt"},
         )

--- a/chameleon_cms_integrations/cms_menus.py
+++ b/chameleon_cms_integrations/cms_menus.py
@@ -19,13 +19,22 @@ class UserMenu(CMSAttachMenu):
         # n = NavigationNode(_('Help Desk'), reverse('djangoRT:ticketcreateguest'), menu_id, attr={'visible_for_authenticated': False, 'class': 'navbar-btn-alt'})
         # nodes.append(n)
         menu_id += 1
-        n = NavigationNode(
-            _("Help Desk"),
-            reverse("djangoRT:ticketcreateguest"),
-            menu_id,
-            attr={"visible_for_anonymous": True, "class": "navbar-btn-alt"},
-        )
-        nodes.append(n)
+        if request.user.is_authenticated:
+            n = NavigationNode(
+                _("Help Desk"),
+                reverse("djangoRT:mytickets"),
+                menu_id,
+                attr={"visible_for_anonymous": True, "class": "navbar-btn-alt"},
+            )
+            nodes.append(n)
+        else:
+            n = NavigationNode(
+                _("Help Desk"),
+                reverse("djangoRT:ticketcreateguest"),
+                menu_id,
+                attr={"visible_for_anonymous": True, "class": "navbar-btn-alt"},
+            )
+            nodes.append(n)
 
         menu_id += 1
         n = NavigationNode(


### PR DESCRIPTION
If a user is authenticated, they are correctly redirected to the "logged in" form, so it's safe to always link to guest form. I

In case users were using this button to go to "My tickets" instead of submitting a new one, it now conditionally updates the menu bar link to handle this.