### PR TITLE
Add timezone info to outage emails

### DIFF
--- a/chameleon_mailman/models.py
+++ b/chameleon_mailman/models.py
@@ -34,16 +34,8 @@ def send_outage_notification(sender, instance, using, **kwargs):
     if instance.resolved:
         subject = "RESOLVED: %s" % subject
 
-    body = (
-        "<b>Outage Start:</b> "
-        + instance.formatted_start_date()
-        + "<br /><br />"
-    )
-    body += (
-        "<b>Outage End:</b> "
-        + instance.formatted_end_date()
-        + "<br /><br />"
-    )
+    body = "<b>Outage Start:</b> " + instance.formatted_start_date() + "<br /><br />"
+    body += "<b>Outage End:</b> " + instance.formatted_end_date() + "<br /><br />"
     body += instance.body
     sender = settings.DEFAULT_FROM_EMAIL
     recipients = settings.OUTAGE_NOTIFICATION_EMAIL.split(",")

--- a/chameleon_mailman/models.py
+++ b/chameleon_mailman/models.py
@@ -36,12 +36,12 @@ def send_outage_notification(sender, instance, using, **kwargs):
 
     body = (
         "<b>Outage Start:</b> "
-        + instance.start_date.strftime("%Y-%m-%d %H:%M")
+        + instance.formatted_start_date()
         + "<br /><br />"
     )
     body += (
         "<b>Outage End:</b> "
-        + instance.end_date.strftime("%Y-%m-%d %H:%M")
+        + instance.formatted_end_date()
         + "<br /><br />"
     )
     body += instance.body

--- a/chameleon_mailman/tasks.py
+++ b/chameleon_mailman/tasks.py
@@ -31,10 +31,10 @@ def send_outage_reminders(crontab_frequency, send_outage_reminder_before):
         if send_window_min < outage.start_date < send_window_max:
             subject = "Outage Reminder: {}".format(outage.title)
             body = "<b>Outage Start:</b> {}<br /><br />".format(
-                outage.start_date.strftime("%Y-%m-%d %H:%M")
+                outage.formatted_start_date()
             )
             body += "<b>Outage End:</b> {}<br /><br />".format(
-                outage.end_date.strftime("%Y-%m-%d %H:%M")
+                outage.formatted_end_date()
             )
             body += outage.body
             sender = settings.DEFAULT_FROM_EMAIL

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -101,8 +101,7 @@ class Outage(News):
     )
 
     def _date_format(self, date):
-        """Format the given date as a nice string for users.
-        """
+        """Format the given date as a nice string for users."""
         utc_str = date.strftime("%H:%M %Z")
         ct_date = date.astimezone(ZoneInfo("America/Chicago"))
         ct_str = ct_date.strftime("%Y-%m-%d %H:%M %Z")

--- a/user_news/models.py
+++ b/user_news/models.py
@@ -1,4 +1,5 @@
 import re
+from zoneinfo import ZoneInfo
 
 from ckeditor.fields import RichTextField
 from cms.models.pluginmodel import CMSPlugin
@@ -98,6 +99,20 @@ class Outage(News):
     severity = models.CharField(
         choices=SEVERITY_LEVEL, blank=False, default="", max_length=50
     )
+
+    def _date_format(self, date):
+        """Format the given date as a nice string for users.
+        """
+        utc_str = date.strftime("%H:%M %Z")
+        ct_date = date.astimezone(ZoneInfo("America/Chicago"))
+        ct_str = ct_date.strftime("%Y-%m-%d %H:%M %Z")
+        return f"{ct_str} ({utc_str})"
+
+    def formatted_end_date(self):
+        return self._date_format(self.end_date)
+
+    def formatted_start_date(self):
+        return self._date_format(self.start_date)
 
     def save(self):
         if not self.slug:


### PR DESCRIPTION
This reformats the outage email (both reminder and new/update emails) to include timezone in Chicago and UTC time, for example '2015-07-01 15:00 CDT  (20:00 UTC)'.