### PR TITLE
Switch from mail to RT for admin operations

### DIFF
--- a/appliance_catalog/views.py
+++ b/appliance_catalog/views.py
@@ -10,7 +10,8 @@ from django.utils.decorators import method_decorator
 from django.views.generic.edit import DeleteView
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
-from django.core.mail import send_mail
+
+from djangoRT import rtModels, rtUtil
 from .forms import ApplianceForm, ApplianceShareForm
 from .models import Appliance, Keyword, ApplianceTagging
 from .serializers import ApplianceJSONSerializer, KeywordJSONSerializer
@@ -261,14 +262,14 @@ def app_create(request):
                     + str(appliance.id)
                 )
                 try:
-                    send_mail(
-                        message,
-                        body,
-                        "noreply@chameleoncloud.org",
-                        ("systems@chameleoncloud.org",),
-                        fail_silently=False,
+                    rt = rtUtil.DjangoRt()
+                    ticket = rtModels.Ticket(
+                        subject=message,
+                        problem_description=body,
+                        requestor="us@tacc.utexas.edu",
                     )
-                except SMTPException as e:
+                    rt.createTicket(ticket)
+                except Exception as e:
                     logger.error("Error sending appliance catalog email ", e)
 
             logger.debug("New appliance successfully created. Adding keywords...")
@@ -329,14 +330,14 @@ def app_create_image(request):
                     + str(appliance.id)
                 )
                 try:
-                    send_mail(
-                        message,
-                        body,
-                        "noreply@chameleoncloud.org",
-                        ("systems@chameleoncloud.org",),
-                        fail_silently=False,
+                    rt = rtUtil.DjangoRt()
+                    ticket = rtModels.Ticket(
+                        subject=message,
+                        problem_description=body,
+                        requestor="us@tacc.utexas.edu",
                     )
-                except SMTPException as e:
+                    rt.createTicket(ticket)
+                except Exception as e:
                     logger.error("Error sending appliance catalog email ", e)
 
             logger.debug("New appliance successfully created. Adding keywords...")

--- a/projects/pub_views.py
+++ b/projects/pub_views.py
@@ -5,7 +5,6 @@ import bibtexparser
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.core.mail import send_mail
 from django.db import transaction
 from django.db.models import Max
 from django.http import Http404
@@ -13,6 +12,7 @@ from django.shortcuts import render
 from django.utils.html import strip_tags
 from django.core.exceptions import PermissionDenied
 
+from djangoRT import rtModels, rtUtil
 from projects.models import Publication, PublicationSource
 from projects.user_publication.deduplicate import get_duplicate_pubs
 from projects.util import get_project_members
@@ -33,13 +33,13 @@ def _send_publication_notification(charge_code, pubs):
     <ul>{" ".join(formatted_pubs)}</ul>
     </p>
     """
-    send_mail(
+    rt = rtUtil.DjangoRt()
+    ticket = rtModels.Ticket(
         subject=subject,
-        from_email=settings.DEFAULT_FROM_EMAIL,
-        recipient_list=[settings.PENDING_ALLOCATION_NOTIFICATION_EMAIL],
-        message=strip_tags(body),
-        html_message=body,
+        problem_description=body,
+        requestor="us@tacc.utexas.edu",
     )
+    rt.createTicket(ticket)
 
 
 def _send_duplicate_pubs_notification(charge_code, duplicate_pubs):
@@ -58,13 +58,13 @@ def _send_duplicate_pubs_notification(charge_code, duplicate_pubs):
     <ul>{" ".join(formatted_duplicate_pubs)}</ul>
     </p>
     """
-    send_mail(
+    rt = rtUtil.DjangoRt()
+    ticket = rtModels.Ticket(
         subject=subject,
-        from_email=settings.DEFAULT_FROM_EMAIL,
-        recipient_list=[settings.PENDING_ALLOCATION_NOTIFICATION_EMAIL],
-        message=strip_tags(body),
-        html_message=body,
+        problem_description=body,
+        requestor="us@tacc.utexas.edu",
     )
+    rt.createTicket(ticket)
 
 
 @login_required

--- a/util/project_allocation_mapper.py
+++ b/util/project_allocation_mapper.py
@@ -43,13 +43,13 @@ class ProjectAllocationMapper:
         <p>Please review the pending allocation request for project {charge_code}
         at <a href="https://{host}/admin/allocations/">admin page</a>.</p>
         """
-        send_mail(
+        rt = rtUtil.DjangoRt()
+        ticket = rtModels.Ticket(
             subject=subject,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[settings.PENDING_ALLOCATION_NOTIFICATION_EMAIL],
-            message=strip_tags(body),
-            html_message=body,
+            problem_description=body,
+            requestor="us@tacc.utexas.edu",
         )
+        rt.createTicket(ticket)
 
     def _send_allocation_decision_notification(
         self, charge_code, requestor_id, status, decision_summary, host


### PR DESCRIPTION
This switches allocations, publications, and appliances mail to RT tickets.

This makes it easier for us to track the history of these items.