### PR TITLE
Add support for flavor reservation

### DIFF
--- a/balance_service/enforcement/usage_enforcement.py
+++ b/balance_service/enforcement/usage_enforcement.py
@@ -226,7 +226,7 @@ class UsageEnforcer(object):
                     self._date_from_string(lease["end_date"])
                 ),
                 hourly_cost=self._get_reservation_sus(
-                    reservation["resource_type"], reservation["allocations"]
+                    reservation
                 ),
             )
             new_charge.save()
@@ -269,7 +269,7 @@ class UsageEnforcer(object):
         self._check_alloc_expiration_date(new_lease, alloc, approved_alloc)
         for reservation in new_lease["reservations"]:
             new_hourly_cost = self._get_reservation_sus(
-                reservation["resource_type"], reservation["allocations"]
+                reservation
             )
             if not end_date_changed:
                 # check if hourly_cost changed
@@ -280,7 +280,7 @@ class UsageEnforcer(object):
                 if len(old_reservation) > 0:
                     old_reservation = old_reservation[0]
                     old_hourly_cost = self._get_reservation_sus(
-                        old_reservation["resource_type"], old_reservation["allocations"]
+                        old_reservation
                     )
                 if new_hourly_cost == old_hourly_cost:
                     # nothing changed
@@ -350,16 +350,29 @@ class UsageEnforcer(object):
 
         return DEFAULT_SU_FACTOR
 
-    def _get_reservation_sus(self, resource_type, allocations):
-        return sum(self.__get_billrate(a, resource_type) for a in allocations)
+    def _get_reservation_sus(self, reservation):
+        resource_type = reservation["resource_type"]
+        allocations = reservation["allocations"]
+        if resource_type == "flavor:instance":
+            # There is 1 allocation per reservation["amount"]
+            running_total = 0
+            for alloc in allocations:
+                su_factor = self.__get_billrate(alloc, resource_type)
+                # What propotion of the host is being used by this reservation
+                host_usage = alloc.get("vcpus", reservation["vcpus"]) / reservation["vcpus"]
+                running_total += su_factor * host_usage
+            return running_total
+        else:
+            return sum(self.__get_billrate(a, resource_type) for a in allocations)
 
     def _total_su_factor(self, lease_values):
+        """Gets the total SUs for the lease.
+        See https://docs.openstack.org/blazar/latest/admin/usage-enforcement.html#externalservicefilter
+        """
         total_su_factor = 0
 
         for reservation in lease_values["reservations"]:
-            resource_type = reservation["resource_type"]
-            allocations = reservation["allocations"]
-            total_su_factor += self._get_reservation_sus(resource_type, allocations)
+            total_su_factor += self._get_reservation_sus(reservation)
 
         return total_su_factor
 


### PR DESCRIPTION
Add support in usage enforcement to support flavor reservation. This differs from host reservation charging, as with flavor reservation not all of the host will be used, and so we charge proportional to this usage.