### PR TITLE
Add admin API for project allocation details

### DIFF
--- a/allocations/urls.py
+++ b/allocations/urls.py
@@ -6,6 +6,7 @@ app_name = "allocations"
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("api/view/<str:charge_code>/", views.view_project, name="view_project"),
     path("view/", views.view, name="view"),
     path("json/", views.return_json, name="return_json"),
     path("approval/", views.approval, name="approval"),

--- a/allocations/views.py
+++ b/allocations/views.py
@@ -1,10 +1,12 @@
 from django.shortcuts import render
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.core import validators
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse, HttpResponseForbidden
 from django.contrib.auth.decorators import login_required, user_passes_test
+from projects.models import Project
 from util.keycloak_client import KeycloakClient
 from util.project_allocation_mapper import ProjectAllocationMapper
 
@@ -80,6 +82,30 @@ def get_all_alloc(request):
 def view(request):
     """Return http response of get_all_alloc. Matches Template."""
     return HttpResponse(get_all_alloc(request), content_type="application/json")
+
+
+def view_project(request, charge_code):
+    provided_token = request.GET.get("token") if request.GET.get("token") else None
+    stored_token = getattr(settings, "PROJECT_ALLOCATION_DETAILS_TOKEN", None)
+    if not provided_token or not stored_token or provided_token != stored_token:
+        logger.error("Project allocation api Access Token validation failed")
+        return HttpResponseForbidden()
+
+    project = Project.objects.get(charge_code=charge_code)
+    is_waiting = project.allocations.filter(
+        status__in=["pending", "approved", "waiting"]).exists()
+    is_active = project.allocations.filter(status="active").exists()
+    furthest_allocation = project.allocations.order_by("-expiration_date").first()
+    data = {
+        "charge_code": project.charge_code,
+        "nickname": project.nickname,
+        "pi": project.pi.email,
+        "status": furthest_allocation.status,
+        "expiration_date": furthest_allocation.expiration_date,
+        "is_active": is_active,
+        "has_pending_allocation": is_waiting,
+    }
+    return JsonResponse(data)
 
 
 @login_required

--- a/allocations/views.py
+++ b/allocations/views.py
@@ -93,7 +93,8 @@ def view_project(request, charge_code):
 
     project = Project.objects.get(charge_code=charge_code)
     is_waiting = project.allocations.filter(
-        status__in=["pending", "approved", "waiting"]).exists()
+        status__in=["pending", "approved", "waiting"]
+    ).exists()
     is_active = project.allocations.filter(status="active").exists()
     furthest_allocation = project.allocations.order_by("-expiration_date").first()
     data = {

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -779,6 +779,7 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 ALLOCATIONS_BALANCE_SERVICE_ROOT_URL = os.environ.get(
     "ALLOCATIONS_BALANCE_SERVICE_ROOT_URL", ""
 )
+PROJECT_ALLOCATION_DETAILS_TOKEN = os.environ.get("PROJECT_ALLOCATION_DETAILS_TOKEN", None)
 
 # check if balance URL starts with https://www.chameleoncloud.org and https://chameleoncloud.org.
 # if it matches, raise an exception to prevent testing against production redis db.


### PR DESCRIPTION
We'd like to use this API in order to check at a Chameleon site if a project has an active allocation. That allows us to clean up resources for projects that have expired.

This new API endpoint is similar to one we have to "project extras", and implements very basic token auth. This endpoint only exposes very basic information as well, some info about the project (in case a site wants to contact a PI), and information about the allocations. This inclues the last date the project had/has an allocation for, if they currently have an active allocation, and if they have a pending allocation. This way, we can adjust our implementation as we see fit around these parameters.