### PR TITLE
Validate length of artifact uuid before calling API

### DIFF
--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -106,7 +106,10 @@ class GitUrlParser:
 
 
 def check_url_param_length(param, length=36):
-    if len(param > length):
+    """If the provided paramter is greater than a given length,
+    then raise a 404 rather than making a request to Trovi.
+    """
+    if len(param) > length:
         raise Http404("That artifact or version does not exist")
 
 


### PR DESCRIPTION
This ensures that we check for a sane UUID length before calling the trovi API to prevent abuse. We only need to do this when getting the artifact. This also fixes a 500 when a version slug being request doesn't exist, and instead raises 404.