### PR TITLE
Task cleanup

### DIFF
--- a/allocations/tasks.py
+++ b/allocations/tasks.py
@@ -478,7 +478,6 @@ def check_keycloak_consistency():
                 keycloak_client.update_project(project, has_active_allocation="false")
 
 
-@task
 def check_charge():
     """
     Check if the charges of the active allocations are in sync

--- a/allocations/tasks.py
+++ b/allocations/tasks.py
@@ -429,9 +429,6 @@ def check_keycloak_consistency():
         for project in Project.objects.filter(~Q(charge_code__in=active_projects))
     )
 
-    LOG.info(f"CONSISTENCY: {len(active_projects)} active allocations")
-    LOG.info(f"CONSISTENCY: {len(inactive_projects)} inactive allocations")
-
     keycloak_client = KeycloakClient()
     groups = keycloak_client._project_admin()
     groups_url = groups._client.get_full_url(
@@ -453,9 +450,6 @@ def check_keycloak_consistency():
             for inactive in ("false", None)
         )
     }
-
-    LOG.info(f"CONSISTENCY: {len(active_groups)} active groups in Keycloak")
-    LOG.info(f"CONSISTENCY: {len(inactive_groups)} inactive groups in Keycloak")
 
     for project in active_projects:
         if project in inactive_groups:

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -796,7 +796,6 @@ PENDING_ALLOCATION_NOTIFICATION_EMAIL = os.environ.get(
 )
 ACTIVATE_EXPIRE_ALLOCATION_FREQUENCY = 60 * 5
 ACTIVATE_EXPIRE_INVITATION_FREQUENCY = 60 * 5
-ALLOCATION_CHECK_CHARGE_FREQUENCY = 60 * 5
 
 ########
 # Tasks
@@ -840,12 +839,6 @@ CELERY_BEAT_SCHEDULE = {
     "warn-user-for-low-allocation": {
         "task": "allocations.tasks.warn_user_for_low_allocations",
         "schedule": crontab(minute=30, hour=7),
-    },
-    "check_charge": {
-        "task": "allocations.tasks.check_charge",
-        "schedule": crontab(
-            minute="*/{}".format(int(ALLOCATION_CHECK_CHARGE_FREQUENCY // 60))
-        ),
     },
 }
 

--- a/projects/user_publication/gscholar.py
+++ b/projects/user_publication/gscholar.py
@@ -97,21 +97,19 @@ class GoogleScholarHandler(object):
         cite_count = 0
         while True:
             try:
-                try:
-                    next_cite = self._get_next_cite(cites_gen)
-                    cited_pub = self.fill(next_cite)
-                    citations.append(cited_pub)
-                    cite_count += 1
-                except Exception as e:
-                    # Some issue with google scholar data's model. Scholarly isn't able
-                    # to map everything via bibtex and random exceptions are raised.
-                    logger.error(e)
-                    continue
-
+                next_cite = self._get_next_cite(cites_gen)
+                cited_pub = self.fill(next_cite)
+                citations.append(cited_pub)
+                cite_count += 1
                 logger.info(f"Got {cite_count} / {num_citations}")
             except StopIteration:
                 logger.info(f"End of iteration. Got {len(citations)} / {num_citations}")
                 return citations
+            except Exception as e:
+                # Some issue with google scholar data's model. Scholarly isn't able
+                # to map everything via bibtex and random exceptions are raised.
+                logger.error(e)
+                continue
 
     @_handle_proxy_reload
     def _get_next_cite(self, cites_gen):

--- a/projects/user_publication/gscholar.py
+++ b/projects/user_publication/gscholar.py
@@ -106,7 +106,6 @@ class GoogleScholarHandler(object):
                     # Some issue with google scholar data's model. Scholarly isn't able
                     # to map everything via bibtex and random exceptions are raised.
                     logger.error(e)
-                    logger.error(f"Error while filling citation for {next_cite}")
                     continue
 
                 logger.info(f"Got {cite_count} / {num_citations}")
@@ -125,7 +124,10 @@ class GoogleScholarHandler(object):
         Args:
             pub (dict): scholarly return of the publication
         """
-        return self.scholarly.fill(pub)
+        try:
+            return self.scholarly.fill(pub)
+        except ValueError:
+            return pub
 
     def get_authors(self, pub):
         """returns a list of authors in a publication

--- a/projects/user_publication/publications.py
+++ b/projects/user_publication/publications.py
@@ -13,22 +13,22 @@ from projects.models import (
 from projects.user_publication import gscholar, scopus, semantic_scholar, utils
 from projects.user_publication.utils import PublicationUtils, update_progress
 from django.db import transaction
-from celery import shared_task
+from celery import task
 
 LOG = logging.getLogger(__name__)
 
 
-@shared_task(bind=True)
+@task(bind=True)
 def import_pubs_scopus_task(self):
     return import_pubs_task(self, "scopus")
 
 
-@shared_task(bind=True)
+@task(bind=True)
 def import_pubs_semantic_scholar_task(self):
     return import_pubs_task(self, "semantic_scholar")
 
 
-@shared_task(bind=True)
+@task(bind=True)
 def import_pubs_google_scholar_task(self):
     return import_pubs_task(self, "gscholar")
 

--- a/projects/user_publication/publications.py
+++ b/projects/user_publication/publications.py
@@ -13,7 +13,7 @@ from projects.models import (
 from projects.user_publication import gscholar, scopus, semantic_scholar, utils
 from projects.user_publication.utils import PublicationUtils, update_progress
 from django.db import transaction
-from celery import task
+from celery.decorators import task
 
 LOG = logging.getLogger(__name__)
 

--- a/projects/user_publication/scopus.py
+++ b/projects/user_publication/scopus.py
@@ -63,7 +63,6 @@ def pub_import(task, dry_run=True):
         if not references:
             continue
         if not _publication_references_chameleon(references):
-            print(raw_pub.title, "Does not referece chameleon")
             continue
         title = utils.decode_unicode_text(raw_pub.title)
         published_on = datetime.datetime.strptime(raw_pub.coverDate, "%Y-%m-%d")


### PR DESCRIPTION
This fixes some general issues with tasks and the pub import tasks.
- Removes unneeded logged in the consistency check. This hasn't been needed for a long time.
- Removes check charge task. Since portal can't connect to the openstack DBs, this does nothing but generate errors. See the commit for more details, but it means that we are slightly overcharging a few users.
- Changes the pub import tasks. I'm not sure why it was working locally for me before, and wasn't running when staged on dev. With these changes, things are working better.