### PR TITLE
Allocations/charges fixes

### DIFF
--- a/allocations/admin.py
+++ b/allocations/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.db import models
+from django import forms
 from django.utils.safestring import mark_safe
 from django.urls import reverse
 
@@ -11,7 +13,22 @@ from .models import Allocation, Charge
 class ChargeInline(admin.TabularInline):
     model = Charge
     extra = 1
-    fields = ["region_name", "user"]
+    fields = [
+        "region_name",
+        "user",
+        "resource_type",
+        "resource_id",
+        "start_time",
+        "end_time",
+        "hourly_cost",
+    ]
+
+    formfield_overrides = {
+        models.TextField: {"widget": forms.TextInput(attrs={"size": "10"})},
+    }
+
+    def has_change_permission(self, request, obj):
+        return False
 
 
 class AllocationAdmin(admin.ModelAdmin):

--- a/balance_service/tests.py
+++ b/balance_service/tests.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 
 import logging
 
+from balance_service.utils import su_calculators
+
 LOG = logging.getLogger(__name__)
 
 from .utils.su_calculators import (
@@ -138,6 +140,41 @@ class BalanceServiceTest(TestCase):
 
     @patch("django.utils.timezone.now")
     @patch("balance_service.utils.openstack.keystone.KeystoneAPI")
+    @patch("balance_service.enforcement.usage_enforcement.KeycloakClient")
+    def test_calculate_user_total_su_usage_deleted_leases(
+        self, mock_kc, mock_ks, mock_now
+    ):
+        mock_now.return_value = self.now
+        # Test calculate_user_total_su_usage function
+        user = self.charge.user  # Assuming a user is associated with the charge
+
+        lease_data = self._lease_data(
+            timezone.timedelta(hours=5),
+            reservations=3,
+            pending_td=timezone.timedelta(hours=5),
+        )
+
+        ks_instance = mock_ks.return_value
+        ks_instance.get_project.return_value = {"id": 123, "name": "TEST123"}
+        ks_instance.get_user.return_value = {"name": "test_requestor"}
+
+        kc_instance = mock_kc.return_value
+        kc_instance.get_user_project_role_scopes.return_value = ("admin", None)
+
+        self.allocation.su_allocated = 10000
+        self.allocation.save()
+
+        ue = UsageEnforcer(ks_instance)
+        # Create charges
+        ue.check_usage_against_allocation(lease_data)
+        # End charges
+        ue.stop_charging(lease_data)
+
+        total_su_usage = calculate_user_total_su_usage(user, self.project)
+        self.assertAlmostEqual(total_su_usage, 21.0, places=2)
+
+    @patch("django.utils.timezone.now")
+    @patch("balance_service.utils.openstack.keystone.KeystoneAPI")
     def test_usage_enforcer_get_remaining_balance(self, mock_ks, mock_now):
         mock_now.return_value = self.now
         ks_instance = mock_ks.return_value
@@ -155,13 +192,14 @@ class BalanceServiceTest(TestCase):
         update_allocations_per_res=2,
         update_su_factor=3,
         update_extend=0,
+        pending_td=timezone.timedelta(days=0),
     ):
-        lease_start = self.now.strftime("%Y-%m-%d %H:%M:%S")
-        lease_end = (self.now + duration_td).strftime("%Y-%m-%d %H:%M:%S")
+        lease_start = (self.now + pending_td).strftime("%Y-%m-%d %H:%M:%S")
+        lease_end = (self.now + pending_td + duration_td).strftime("%Y-%m-%d %H:%M:%S")
 
-        update_start = self.now.strftime("%Y-%m-%d %H:%M:%S")
+        update_start = (self.now + pending_td).strftime("%Y-%m-%d %H:%M:%S")
         update_end = (
-            self.now + duration_td + timezone.timedelta(days=update_extend)
+            self.now + pending_td + duration_td + timezone.timedelta(days=update_extend)
         ).strftime("%Y-%m-%d %H:%M:%S")
 
         if not include_update:
@@ -658,4 +696,42 @@ class BalanceServiceTest(TestCase):
         # Ensure all charges end now, when stopped
         for c in Charge.objects.all():
             if c not in self.existing_charges:
+                self.assertEqual(c.end_time, self.now)
+
+    @patch("django.utils.timezone.now")
+    @patch("balance_service.utils.openstack.keystone.KeystoneAPI")
+    @patch("balance_service.enforcement.usage_enforcement.KeycloakClient")
+    def test_usage_enforcer_stop_charging_pending_lease(
+        self, mock_kc, mock_ks, mock_now
+    ):
+        mock_now.return_value = self.now
+
+        ks_instance = mock_ks.return_value
+        ks_instance.get_project.return_value = {"id": 123, "name": "TEST123"}
+        ks_instance.get_user.return_value = {"name": "test_requestor"}
+
+        kc_instance = mock_kc.return_value
+        kc_instance.get_user_project_role_scopes.return_value = ("admin", None)
+
+        ue = UsageEnforcer(ks_instance)
+
+        self.allocation.su_allocated = 10000
+        self.allocation.save()
+
+        lease_data = self._lease_data(
+            timezone.timedelta(hours=5),
+            reservations=3,
+            pending_td=timezone.timedelta(hours=5),
+        )
+
+        # Create charges
+        ue.check_usage_against_allocation(lease_data)
+        # End charges
+        ue.stop_charging(lease_data)
+        # mock_now.return_value = self.now + timezone.timedelta(hours=24)
+
+        # Ensure all charges end now, when stopped
+        for c in Charge.objects.all():
+            if c not in self.existing_charges:
+                self.assertEqual(su_calculators.get_total_sus(c), 0)
                 self.assertEqual(c.end_time, self.now)

--- a/util/project_allocation_mapper.py
+++ b/util/project_allocation_mapper.py
@@ -183,7 +183,7 @@ class ProjectAllocationMapper:
                 for b in project_balances(project_ids):
                     charge_code = b.get("charge_code")
                     if charge_code:
-                        all_active_allocations[charge_code].su_used = b.get("used")
+                        all_active_allocations[charge_code].su_used = b.get("total")
 
         return projects
 


### PR DESCRIPTION
This fixes 2 issues with allocations/charges on the project overview pages
- Usage would appear with negative SUs for a specific user's budget if they deleted a pending lease. When a lease is deleted we just update end time of the charge, and we [check for negative values](https://github.com/ChameleonCloud/portal/blob/master/balance_service/utils/su_calculators.py#L9-L27) typicall. However, we didn't go through these functions for user budgets, since there we are using database queries to calculate the user's usage. This is fixed with a `Case` statement in the django db query.
- Users would get "not enough SUs" error or the "SUs almost used" warning email but their dashboard would show a low number of SUs used. That is because we track 2 numbers: SUs used, and SUs encumbered. This updates the project displays to use "total" (used + encumbered) instead of just "used".