### PR TITLE
Fix overview/help desk loading issues

### DIFF
--- a/chameleon/templates/dashboard.html
+++ b/chameleon/templates/dashboard.html
@@ -91,25 +91,29 @@
         </div>
       </div>
       <div class="panel-body">
-        {% if open_tickets %}
-          <table class="table">
-            <thead>
-              <th>Ticket</th>
-              <th>Last Updated</th>
-              <th></th>
-            </thead>
-            <tbody>
-              {% for ticket in open_tickets %}
-                <tr>
-                <td><a href="{% url 'djangoRT:ticketdetail' ticket.id %}">#{{ticket.id}} - {{ticket.Subject}}</a></td>
-                <td>{{ticket.LastUpdated|naturaltime}}</td>
-                <td class="text-right"><a href="{% url 'djangoRT:ticketreply' ticket.id %}">Reply</a></td>
-                </tr>
-              {% endfor %}
-            <tbody>
-          </table>
+        {% if not logged_in_tickets %}
+          <p class="alert alert-danger">Could not connect to the help desk. Please try again later.</p>
         {% else %}
-          <p>No open tickets.</p>
+          {% if open_tickets %}
+            <table class="table">
+              <thead>
+                <th>Ticket</th>
+                <th>Last Updated</th>
+                <th></th>
+              </thead>
+              <tbody>
+                {% for ticket in open_tickets %}
+                  <tr>
+                  <td><a href="{% url 'djangoRT:ticketdetail' ticket.id %}">#{{ticket.id}} - {{ticket.Subject}}</a></td>
+                  <td>{{ticket.LastUpdated|naturaltime}}</td>
+                  <td class="text-right"><a href="{% url 'djangoRT:ticketreply' ticket.id %}">Reply</a></td>
+                  </tr>
+                {% endfor %}
+              <tbody>
+            </table>
+          {% else %}
+            <p>No open tickets.</p>
+          {% endif %}
         {% endif %}
       </div>
     </div>

--- a/chameleon/views.py
+++ b/chameleon/views.py
@@ -51,6 +51,7 @@ def dashboard(request):
     # open tickets...
     rt = rtUtil.DjangoRt()
     context["open_tickets"] = rt.getUserTickets(request.user.email)
+    context["logged_in_tickets"] = rt.logged_in
 
     # ongoing outages...
     outages = [

--- a/djangoRT/rtUtil.py
+++ b/djangoRT/rtUtil.py
@@ -17,9 +17,11 @@ class DjangoRt:
         self.queue = settings.DJANGO_RT["RT_QUEUE"]
 
         self.tracker = rt.Rt(host, username, password)
-        self.tracker.login()
+        self.logged_in = self.tracker.login()
 
     def getUserTickets(self, userEmail, show_resolved=False):
+        if not self.logged_in:
+            return []
         if show_resolved:
             query = 'Requestor="%s"' % userEmail
         else:

--- a/djangoRT/templates/djangoRT/ticketList.html
+++ b/djangoRT/templates/djangoRT/ticketList.html
@@ -26,12 +26,17 @@
 </form>
 
 <div class="tickets">
-  {% for ticket in tickets %}
-    {% include "djangoRT/ticket.html" %}
-  {% empty %}
-    <div class="jumbotron">
-      <p>No tickets to display!</p>
-    </div>
-  {% endfor %}
+  {% if not logged_in %}
+    <p class="alert alert-danger">Could not connect to the help desk. Please try again later.</p>
+  {% else %}
+    {% for ticket in tickets %}
+      {% include "djangoRT/ticket.html" %}
+    {% empty %}
+      <div class="jumbotron">
+        <p>No tickets to display!</p>
+      </div>
+    {% endfor %}
+  {% endif %}
+
 </div>
 {% endblock %}

--- a/djangoRT/views.py
+++ b/djangoRT/views.py
@@ -125,6 +125,7 @@ def mytickets(request):
         "djangoRT/ticketList.html",
         {
             "tickets": tickets,
+            "logged_in": rt.logged_in,
             "show_resolved": show_resolved,
         },
     )


### PR DESCRIPTION
If the helpdesk isn't working, show an error message instead. This only checks on the ticket list pages. The other ticket pages will show the normal error page. 

The main improvement is this fixes the dashboard loading if RT is not configured or is down.