### PR TITLE
Fix config for local dev

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -40,6 +40,7 @@ DB_PASSWORD=ccpass
 
 # Uncomment to run in Production mode
 # DJANGO_ENV=Production
+DJANGO_ENV=DEBUG
 
 # Configure Google Analytics property ID
 # GOOGLE_ANALYTICS_PROPERTY_ID=
@@ -58,16 +59,17 @@ OPENSTACK_SERVICE_PASSWORD=
 OPENSTACK_SERVICE_PROJECT_ID=4e9f3b6fbaf245e780b25fae2c166d4e
 
 # Email
-SMTP_HOST=relay.tacc.utexas.edu
-SMTP_PORT=25
-SMTP_USER=
-SMTP_PASSWORD=
+SMTP_HOST=127.0.0.1
+SMTP_PORT=8025
+SMTP_USER=cc
+SMTP_PASSWORD=ccpass
 OUTAGE_NOTIFICATION_EMAIL=
 DEFAULT_FROM_EMAIL=no-reply@chameleoncloud.org
 
 # Trovi
 ZENODO_URL=https://sandbox.zenodo.org
 ARTIFACT_SHARING_JUPYTERHUB_URL=http://localhost:8001
+TROVI_API_BASE_URL=https://trovi-dev.chameleoncloud.org
 
 # Allocations
 ALLOCATIONS_BALANCE_SERVICE_ROOT_URL=http://allocations_api:8080

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ ifneq (,$(wildcard ./.env))
 endif
 
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
-DOCKER_IMAGE ?= $(DOCKER_REGISTRY)/portal:$(DOCKER_TAG)
-DOCKER_IMAGE_LATEST ?= $(DOCKER_REGISTRY)/portal:latest
+DOCKER_IMAGE ?= portal:$(DOCKER_TAG)
+DOCKER_IMAGE_LATEST ?= portal:latest
 
 ifeq ($(shell arch),arm64)
 	PY_IMG = arm64v8/python
@@ -41,7 +41,7 @@ publish-latest:
 
 .PHONY: start
 start: .env
-	docker-compose $(ENV_FILE_PARAM) up -d
+	docker compose $(ENV_FILE_PARAM) up -d
 
 .PHONY: clean
 clean:
@@ -49,7 +49,7 @@ clean:
 
 .PHONY: migrations
 migrations: start
-	docker-compose exec portal python manage.py makemigrations --check
+	docker compose exec portal python manage.py makemigrations --check
 
 requirements-frozen.txt: build
 	docker run --rm $(DOCKER_IMAGE) pip freeze > $@

--- a/chameleon/settings.py
+++ b/chameleon/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "NOT_A_SECRET")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-DEBUG
-DEBUG = os.environ.get("DJANGO_ENV", "DEBUG") == "DEBUG"
+DEBUG = os.environ.get("DJANGO_ENV", "debug").lower() == "debug"
 
 # OpenStack Properties
 OPENSTACK_UC_REGION = os.environ.get("OPENSTACK_UC_REGION", "CHI@UC")
@@ -841,6 +841,8 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(minute=30, hour=7),
     },
 }
+if DEBUG:
+    CELERY_BEAT_SCHEDULE = {}
 
 # Djangocms_blog templates
 BLOG_PLUGIN_TEMPLATE_FOLDERS = (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
     command: ["runserver", "0.0.0.0:${PORTAL_PORT}"]
     depends_on:
       - mysql
+  referenceapi:
+    image: ghcr.io/chameleoncloud/reference-api:latest
+    ports:
+      - "127.0.0.1:8891:8000"
   mysql:
     image: mariadb:10
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   portal:
     image: ${DOCKER_IMAGE_LATEST}
@@ -21,10 +19,6 @@ services:
     command: ["runserver", "0.0.0.0:${PORTAL_PORT}"]
     depends_on:
       - mysql
-  referenceapi:
-    image: docker.chameleoncloud.org/referenceapi:latest
-    ports:
-      - "127.0.0.1:8891:8000"
   mysql:
     image: mariadb:10
     volumes:
@@ -41,15 +35,6 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
     ports:
       - "127.0.0.1:3306:3306"
-  phpmyadmin:
-    image: phpmyadmin/phpmyadmin
-    ports:
-      - "127.0.0.1:8889:80"
-    environment:
-      - PMA_HOST=mysql
-      - PMA_PORT=3306
-    depends_on:
-      - mysql
   redis:
     image: redis:alpine
   celery:


### PR DESCRIPTION
This fixes debug logs, `docker-compose` -> `docker compose`, and some default env variables. Also removes phpmyadmin, since I don't think anyone uses it, and referenceapi since that container image can't be pulled.