### PR TITLE
Improve trovi page with paginated API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ CLAUDE.md
 portal_dev_2025_05_09.sql
 .gitignore
 static/images/.DS_Store
+
+static/styles/tmp*

--- a/sharing_portal/templates/sharing_portal/includes/artifact_cards.html
+++ b/sharing_portal/templates/sharing_portal/includes/artifact_cards.html
@@ -1,0 +1,25 @@
+{% for artifact in artifacts %}
+<div class="cardItem" data-search="{{ artifact.search_terms|join:' ' }}">
+  <a class="blockLink" href="{% url 'sharing_portal:detail' artifact.uuid %}">
+    <h5 class="cardItem__title">
+      <span class="cardTitleTitle">{{ artifact.title }}</span>
+      <span class="cardTitlePrivate">
+        {% if artifact.is_private and not artifact.has_doi %}
+        <i class="fa fa-eye-slash" data-toggle="tooltip" data-placement="top"
+           title="This artifact is only visible for those chosen by the author"></i>
+        {% endif %}
+      </span>
+    </h5>
+    <div class="cardItem__body">
+      {% if artifact.short_description %}
+      <p class="artifactGridItem__description">
+        {{ artifact.short_description }}
+      </p>
+      {% endif %}
+    </div>
+  </a>
+  <div class="cardItem__footer">
+    {% include 'sharing_portal/includes/stats.html' with artifact=artifact %}
+  </div>
+</div>
+{% endfor %}

--- a/sharing_portal/templates/sharing_portal/index.html
+++ b/sharing_portal/templates/sharing_portal/index.html
@@ -19,39 +19,12 @@
   <div class="layoutGrid__main">
     <input id="cardFilter" class="cardFilter" type="text" placeholder="Filter"/>
 
-    <!-- <h3>Featured Artifacts</h3> -->
-<!-- 
-    <div>
-      {% for artifact in featured_artifacts %}
-      <div class="cardItem" data-search="{{ artifact.search_terms|join:' ' }}">
-        <a class="blockLink" href="{% url 'sharing_portal:detail' artifact.uuid %}">
-          <h5 class="cardItem__title">
-            <span class="cardTitleTitle">{{ artifact.title }}</span>
-            <span class="cardTitlePrivate">
-          {% if artifact.is_private and not artifact.has_doi %}
-            <i class="fa fa-eye-slash" data-toggle="tooltip" data-placement="top"
-               title="This artifact is only visible for those chosen by the author"></i>
-          {% endif %}
-          </span>
-          </h5>
-          <div class="cardItem__body">
-            {% if artifact.short_description %}
-            <p class="artifactGridItem__description">
-              {{ artifact.short_description }}
-            </p>
-            {% endif %}
-          </div>
-        </a>
-        <div class="cardItem__footer">
-          {% include 'sharing_portal/includes/stats.html' with artifact=artifact %}
-        </div>
-      </div>
-      {% empty %}
-      <div class="cardEmpty">
-        <p>No results found.</p>
-      </div>
-      {% endfor %}
-    </div> -->
+    <h3>Featured Artifacts</h3>
+    <div id="featured-artifact-list">
+      {% with featured_artifacts as artifacts %}
+        {% include "sharing_portal/includes/artifact_cards.html" %}
+      {% endwith %}
+    </div>
 
     <h3>All Artifacts</h3>
 
@@ -74,6 +47,9 @@
 
         document.getElementById("artifact-list")
           .insertAdjacentHTML("beforeend", data.html);
+
+        document.getElementById("featured-artifact-list")
+          .insertAdjacentHTML("beforeend", data.featured_html);
 
         after = data.next_cursor;
         console.log(after, typeof(after))

--- a/sharing_portal/templates/sharing_portal/index.html
+++ b/sharing_portal/templates/sharing_portal/index.html
@@ -19,8 +19,8 @@
   <div class="layoutGrid__main">
     <input id="cardFilter" class="cardFilter" type="text" placeholder="Filter"/>
 
-    <h3>Featured Artifacts</h3>
-
+    <!-- <h3>Featured Artifacts</h3> -->
+<!-- 
     <div>
       {% for artifact in featured_artifacts %}
       <div class="cardItem" data-search="{{ artifact.search_terms|join:' ' }}">
@@ -51,41 +51,38 @@
         <p>No results found.</p>
       </div>
       {% endfor %}
-    </div>
+    </div> -->
 
     <h3>All Artifacts</h3>
 
-    <div>
-      {% for artifact in artifacts %}
-      <div class="cardItem" data-search="{{ artifact.search_terms|join:' ' }}">
-        <a class="blockLink" href="{% url 'sharing_portal:detail' artifact.uuid %}">
-          <h5 class="cardItem__title">
-            <span class="cardTitleTitle">{{ artifact.title }}</span>
-            <span class="cardTitlePrivate">
-              {% if artifact.is_private and not artifact.has_doi %}
-            <i class="fa fa-eye-slash" data-toggle="tooltip" data-placement="top"
-               title="This artifact is only visible for those chosen by the author"></i>
-          {% endif %}
-          </span>
-          </h5>
-          <div class="cardItem__body">
-            {% if artifact.short_description %}
-            <p class="artifactGridItem__description">
-              {{ artifact.short_description }}
-            </p>
-            {% endif %}
-          </div>
-        </a>
-        <div class="cardItem__footer">
-          {% include 'sharing_portal/includes/stats.html' with artifact=artifact %}
-        </div>
-      </div>
-      {% empty %}
-      <div class="cardEmpty">
-        <p>No results found.</p>
-      </div>
-      {% endfor %}
+    <div id="artifact-list">
+      {% include "sharing_portal/includes/artifact_cards.html" %}
     </div>
+    
+    <div id="pagination-data" data-after="{{ next_cursor }}"></div>
+    
+    <script>
+    async function loadAllArtifacts() {
+      let after = document.getElementById("pagination-data").dataset.after;
+      if (!after) return; // No more pages from the start
+
+      while (after) {
+        const resp = await fetch(`?after=${after}`, {
+          headers: { "X-Requested-With": "XMLHttpRequest" }
+        });
+        const data = await resp.json();
+
+        document.getElementById("artifact-list")
+          .insertAdjacentHTML("beforeend", data.html);
+
+        after = data.next_cursor;
+        console.log(after, typeof(after))
+      }
+    }
+
+    document.addEventListener("DOMContentLoaded", loadAllArtifacts);
+    </script>
+    
   </div>
 
   <div class="layoutGrid__side">

--- a/sharing_portal/trovi.py
+++ b/sharing_portal/trovi.py
@@ -96,11 +96,15 @@ def list_artifacts(token, sort_by="-updated_at", after=None, limit=None):
     if not after:
         after = ""
     res = requests.get(
-        url_with_token("/artifacts/", token, query=dict(
-            sort_by=sort_by,
-            after=after,
-            limit=limit,
-        ))
+        url_with_token(
+            "/artifacts/",
+            token,
+            query=dict(
+                sort_by=sort_by,
+                after=after,
+                limit=limit,
+            ),
+        )
     )
     check_status(res, requests.codes.ok)
     return res.json()["artifacts"]

--- a/sharing_portal/trovi.py
+++ b/sharing_portal/trovi.py
@@ -92,9 +92,15 @@ def get_token(token, is_admin=False):
     return res.json()
 
 
-def list_artifacts(token, sort_by="updated_at"):
+def list_artifacts(token, sort_by="-updated_at", after=None, limit=None):
+    if not after:
+        after = ""
     res = requests.get(
-        url_with_token("/artifacts/", token, query=dict(sort_by=sort_by))
+        url_with_token("/artifacts/", token, query=dict(
+            sort_by=sort_by,
+            after=after,
+            limit=limit,
+        ))
     )
     check_status(res, requests.codes.ok)
     return res.json()["artifacts"]

--- a/sharing_portal/views.py
+++ b/sharing_portal/views.py
@@ -273,9 +273,7 @@ def _trovi_artifacts(request, limit=20, after=None):
     artifacts = [
         _compute_artifact_fields(a)
         for a in trovi.list_artifacts(
-            request.session.get("trovi_token"),
-            sort_by="updated_at",
-            **kwargs
+            request.session.get("trovi_token"), sort_by="updated_at", **kwargs
         )
         # NOTE: Due to a bug in trovi, we must filter out the marker artifact
         if a["uuid"] != after
@@ -296,7 +294,8 @@ def _render_list(request, owned=False, public=False):
 
     raw_artifacts = _trovi_artifacts(request, limit=limit, after=after)
     artifacts = [
-        a for a in raw_artifacts
+        a
+        for a in raw_artifacts
         if (
             (not owned or _owns_artifact(request.user, a))
             and (not public or (a["visibility"] == "public" or a["has_doi"]))
@@ -304,12 +303,8 @@ def _render_list(request, owned=False, public=False):
     ]
 
     featured_uuids = {str(f.artifact_uuid) for f in FeaturedArtifact.objects.all()}
-    featured_artifacts = [
-        a for a in artifacts if a["uuid"] in featured_uuids
-    ]
-    other_artifacts = [
-        a for a in artifacts if a["uuid"] not in featured_uuids
-    ]
+    featured_artifacts = [a for a in artifacts if a["uuid"] in featured_uuids]
+    other_artifacts = [a for a in artifacts if a["uuid"] not in featured_uuids]
 
     if raw_artifacts:
         next_cursor = raw_artifacts[-1]["uuid"]
@@ -319,18 +314,16 @@ def _render_list(request, owned=False, public=False):
         html = render(
             request,
             "sharing_portal/includes/artifact_cards.html",
-            {"artifacts": other_artifacts}
+            {"artifacts": other_artifacts},
         ).content.decode("utf-8")
         featured_html = render(
             request,
             "sharing_portal/includes/artifact_cards.html",
-            {"artifacts": featured_artifacts}
+            {"artifacts": featured_artifacts},
         ).content.decode("utf-8")
-        return JsonResponse({
-            "html": html,
-            "featured_html": featured_html,
-            "next_cursor": next_cursor
-        })
+        return JsonResponse(
+            {"html": html, "featured_html": featured_html, "next_cursor": next_cursor}
+        )
 
     # Normal page load
     template = loader.get_template("sharing_portal/index.html")
@@ -385,7 +378,7 @@ def _delete_artifact_version(request, version):
         messages.add_message(
             request,
             messages.ERROR,
-            f"Cannot delete versions " f"already assigned a DOI. ({version})",
+            f"Cannot delete versions already assigned a DOI. ({version})",
         )
         return False
 


### PR DESCRIPTION
This adds AJAX pagination to trovi. We must still render server side,
since it would take too much development time to properly handle this
in the frontend. We can't do a typical pagination, with page buttons
since the Trovi API doesn't support this, and that would break
searching. So now it makes repeated requests for artifacts, and portal
responds with SSRed artifact cards.
