### PR TITLE
Fix filter_users_by_claims to also use email

### DIFF
--- a/chameleon/ChameleonOIDCAuthBackend.py
+++ b/chameleon/ChameleonOIDCAuthBackend.py
@@ -37,10 +37,13 @@ class ChameleonOIDCAB(OIDCAuthenticationBackend):
         return login
 
     def filter_users_by_claims(self, claims):
-        """Override to search for users by username and not email."""
+        """Override to search for users by username and email."""
         username = claims.get("preferred_username")
         if username:
             return self.UserModel.objects.filter(username__iexact=username)
+        email = claims.get("email")
+        if email:
+            return self.UserModel.objects.filter(email__iexact=email)
 
         return self.UserModel.objects.none()
 


### PR DESCRIPTION
The mapping from OIDC user_info -> django user by default uses email.

https://mozilla-django-oidc.readthedocs.io/en/stable/installation.html#connecting-oidc-user-identities-to-django-users

The issue we are seeing is after re-linking in keycloak, a second portal account is being generated for the same keycloak user.