### PR TITLE
Add appliance catalog deprecation warning and link to trovi+docs

### DIFF
--- a/appliance_catalog/templates/appliance_catalog/list.html
+++ b/appliance_catalog/templates/appliance_catalog/list.html
@@ -17,6 +17,12 @@
     <div id="content-main" class="appCatalog" ng-app="appCatalogApp" ng-cloak ng-csp>
         <div class="content" ng-controller="AppCatalogController">
             <h2>Appliance Catalog</h2>
+            <div class="alert alert-warning alert-dismissible fade in" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <strong>Deprecated:</strong> The Appliance Catalog is deprecated and should no longer be used. Please find and submit appliances on <a href="https://trovi.chameleoncloud.org/dashboard/?tags=appliance" target="_blank">Trovi</a>. See <a href="https://chameleoncloud.readthedocs.io/en/latest/technical/complex/catalog.html#complex-appliances-in-trovi" target="_blank">documentation</a> for more information.
+            </div>
             {% if request.user.is_authenticated %}
             <div class="add-appliance-link">
                 <a class="btn btn-success" href="create/">


### PR DESCRIPTION
<img width="1223" height="473" alt="Screenshot 2026-03-30 at 12 55 36" src="https://github.com/user-attachments/assets/618ad439-8268-44b9-98b2-315f8cf465e8" />
