### PR TITLE
fix(hardware-browser): prevent shared reference breaking filter

### DIFF
--- a/g5k_discovery/vue/HardwareDetails.vue
+++ b/g5k_discovery/vue/HardwareDetails.vue
@@ -149,7 +149,7 @@ export default {
       let allCapabilities = {};
 
       if (discover) {
-        const discoveredCaps = JSPath.apply(discover.prefix, this.hardware)[0] || {};
+        const discoveredCaps = { ...(JSPath.apply(discover.prefix, this.hardware)[0] || {}) };
         if (discover.ignore) {
           discover.ignore.forEach((key) => delete discoveredCaps[key]);
         }


### PR DESCRIPTION
"ignore" caused delete to be called on discoveredCaps keys. As this was a shared reference, it strips keys from the list of storage devices, preventing later checks for "interface" or total capacity from returning correctly.

This manifested as nvme returning false for nodes with a single nvme drive, but true for nodes with >1 nvme drive.
The fix does a shallow-copy instead, preventing the mutation.

This needs testing, but I *think* it's the right thing? Unfortunately not as familiar with JS as I'd like...